### PR TITLE
Feature/#9: 온보딩 아보카도 생성

### DIFF
--- a/src/main/java/software_capstone/backend/app/abocado/controller/AbocadoController.java
+++ b/src/main/java/software_capstone/backend/app/abocado/controller/AbocadoController.java
@@ -1,0 +1,27 @@
+package software_capstone.backend.app.abocado.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import software_capstone.backend.app.abocado.dto.AbocadoOnboardingRequest;
+import software_capstone.backend.app.abocado.service.AbocadoService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/abocado")
+public class AbocadoController {
+
+    private final AbocadoService abocadoService;
+
+    @PostMapping("/onboarding")
+    public ResponseEntity<Void> onBoarding(
+            @AuthenticationPrincipal String userId,
+            AbocadoOnboardingRequest request
+    ) {
+        abocadoService.onBoarding(userId, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/software_capstone/backend/app/abocado/controller/AbocadoController.java
+++ b/src/main/java/software_capstone/backend/app/abocado/controller/AbocadoController.java
@@ -1,5 +1,8 @@
 package software_capstone.backend.app.abocado.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +19,26 @@ public class AbocadoController {
 
     private final AbocadoService abocadoService;
 
+    @Operation(
+            summary = "유저 온보딩",
+            description =
+                    """
+                    새로운 유저가 서비스에 처음 접근 시에 사용합니다.
+                    
+                    새로운 아보카도에 대한 이름, 유저가 설정한 난이도를 body에 담아 요청해야 합니다.
+                    
+                    생성 이후, 반환값은 없지만 자동적으로 아보카도가 생성되며 레벨과 경험치를 초기값으로 설정합니다.
+                    
+                    토큰으로 받아온 유저가 존재하지 않다면 에러가 발생합니다.
+                    
+                    difficulty: EASY, NORMAL, HARD
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "온보딩 요청 성공"),
+            @ApiResponse(responseCode = "403", description = "토큰을 담아 요청하지 않음"),
+            @ApiResponse(responseCode = "404", description = "유저가 존재하지 않음")
+    })
     @PostMapping("/onboarding")
     public ResponseEntity<Void> onBoarding(
             @AuthenticationPrincipal String userId,

--- a/src/main/java/software_capstone/backend/app/abocado/controller/AbocadoController.java
+++ b/src/main/java/software_capstone/backend/app/abocado/controller/AbocadoController.java
@@ -3,10 +3,12 @@ package software_capstone.backend.app.abocado.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import software_capstone.backend.app.abocado.dto.AbocadoOnboardingRequest;
@@ -42,7 +44,7 @@ public class AbocadoController {
     @PostMapping("/onboarding")
     public ResponseEntity<Void> onBoarding(
             @AuthenticationPrincipal String userId,
-            AbocadoOnboardingRequest request
+            @RequestBody @Valid AbocadoOnboardingRequest request
     ) {
         abocadoService.onBoarding(userId, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/software_capstone/backend/app/abocado/document/Abocado.java
+++ b/src/main/java/software_capstone/backend/app/abocado/document/Abocado.java
@@ -1,0 +1,30 @@
+package software_capstone.backend.app.abocado.document;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.Indexed;
+import software_capstone.backend.global.document.BaseEntity;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Abocado extends BaseEntity {
+
+    @Indexed
+    private String userId;
+
+    private String name;
+
+    @Builder.Default
+    private Level level = Level.ONE; // 생성 시에 초기 레벨은 1
+
+    @Builder.Default
+    private int exp = 0; // 생성 시에 기본 경험치는 없음
+
+    @Builder.Default
+    private boolean isActive = true; // 현재 성장시키고 있는 객체인지 판독
+}

--- a/src/main/java/software_capstone/backend/app/abocado/document/Abocado.java
+++ b/src/main/java/software_capstone/backend/app/abocado/document/Abocado.java
@@ -6,12 +6,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
 import software_capstone.backend.global.document.BaseEntity;
 
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Document(collection = "abocados")
 public class Abocado extends BaseEntity {
 
     @Indexed

--- a/src/main/java/software_capstone/backend/app/abocado/document/Difficulty.java
+++ b/src/main/java/software_capstone/backend/app/abocado/document/Difficulty.java
@@ -1,0 +1,5 @@
+package software_capstone.backend.app.abocado.document;
+
+public enum Difficulty {
+    EASY, NORMAL, HARD
+}

--- a/src/main/java/software_capstone/backend/app/abocado/document/Level.java
+++ b/src/main/java/software_capstone/backend/app/abocado/document/Level.java
@@ -1,0 +1,17 @@
+package software_capstone.backend.app.abocado.document;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Level {
+    ONE(100),
+    TWO(250),
+    THREE(450);
+
+    // 다음 레벨로 가기 위한 경험치량, 임시 값으로 넣어둔 상태
+    // TODO: 기획 확립 시 이 값을 변경해야 함
+    private final int expToNextLevel;
+}

--- a/src/main/java/software_capstone/backend/app/abocado/dto/AbocadoOnboardingRequest.java
+++ b/src/main/java/software_capstone/backend/app/abocado/dto/AbocadoOnboardingRequest.java
@@ -1,9 +1,11 @@
 package software_capstone.backend.app.abocado.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import software_capstone.backend.app.abocado.document.Difficulty;
 
 public record AbocadoOnboardingRequest(
-        String name,
-        Difficulty difficulty
+        @NotBlank String name,
+        @NotNull Difficulty difficulty
 ) {
 }

--- a/src/main/java/software_capstone/backend/app/abocado/dto/AbocadoOnboardingRequest.java
+++ b/src/main/java/software_capstone/backend/app/abocado/dto/AbocadoOnboardingRequest.java
@@ -1,0 +1,9 @@
+package software_capstone.backend.app.abocado.dto;
+
+import software_capstone.backend.app.abocado.document.Difficulty;
+
+public record AbocadoOnboardingRequest(
+        String name,
+        Difficulty difficulty
+) {
+}

--- a/src/main/java/software_capstone/backend/app/abocado/repository/AbocadoRepository.java
+++ b/src/main/java/software_capstone/backend/app/abocado/repository/AbocadoRepository.java
@@ -1,0 +1,7 @@
+package software_capstone.backend.app.abocado.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import software_capstone.backend.app.abocado.document.Abocado;
+
+public interface AbocadoRepository extends MongoRepository<Abocado, String> {
+}

--- a/src/main/java/software_capstone/backend/app/abocado/service/AbocadoService.java
+++ b/src/main/java/software_capstone/backend/app/abocado/service/AbocadoService.java
@@ -1,0 +1,31 @@
+package software_capstone.backend.app.abocado.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import software_capstone.backend.app.abocado.document.Abocado;
+import software_capstone.backend.app.abocado.dto.AbocadoOnboardingRequest;
+import software_capstone.backend.app.abocado.repository.AbocadoRepository;
+import software_capstone.backend.app.user.document.User;
+import software_capstone.backend.app.user.service.UserService;
+
+@Service
+@RequiredArgsConstructor
+public class AbocadoService {
+
+    private final UserService userService;
+    private final AbocadoRepository abocadoRepository;
+
+    public void onBoarding(
+            String userId,
+            AbocadoOnboardingRequest request
+    ) {
+        abocadoRepository.save(
+                Abocado.builder()
+                        .userId(userId)
+                        .name(request.name())
+                        .build());
+
+        User user = userService.findUserById(userId);
+        user.updateDifficulty(request.difficulty());
+    }
+}

--- a/src/main/java/software_capstone/backend/app/abocado/service/AbocadoService.java
+++ b/src/main/java/software_capstone/backend/app/abocado/service/AbocadoService.java
@@ -6,6 +6,7 @@ import software_capstone.backend.app.abocado.document.Abocado;
 import software_capstone.backend.app.abocado.dto.AbocadoOnboardingRequest;
 import software_capstone.backend.app.abocado.repository.AbocadoRepository;
 import software_capstone.backend.app.user.document.User;
+import software_capstone.backend.app.user.repository.UserRepository;
 import software_capstone.backend.app.user.service.UserService;
 
 @Service
@@ -14,6 +15,7 @@ public class AbocadoService {
 
     private final UserService userService;
     private final AbocadoRepository abocadoRepository;
+    private final UserRepository userRepository;
 
     public void onBoarding(
             String userId,
@@ -27,5 +29,6 @@ public class AbocadoService {
 
         User user = userService.findUserById(userId);
         user.updateDifficulty(request.difficulty());
+        userRepository.save(user); // MongoDB는 JPA와 달리 영속성 컨텍스트가 없기에, 저장을 반영하려면 save 메서드 필요
     }
 }

--- a/src/main/java/software_capstone/backend/app/abocado/service/AbocadoService.java
+++ b/src/main/java/software_capstone/backend/app/abocado/service/AbocadoService.java
@@ -2,6 +2,7 @@ package software_capstone.backend.app.abocado.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import software_capstone.backend.app.abocado.document.Abocado;
 import software_capstone.backend.app.abocado.dto.AbocadoOnboardingRequest;
 import software_capstone.backend.app.abocado.repository.AbocadoRepository;
@@ -17,6 +18,8 @@ public class AbocadoService {
     private final AbocadoRepository abocadoRepository;
     private final UserRepository userRepository;
 
+    // 메서드가 2개 이상의 컬렉션을 다루고 있기에, @Transaction 필요
+    @Transactional
     public void onBoarding(
             String userId,
             AbocadoOnboardingRequest request

--- a/src/main/java/software_capstone/backend/app/abocado/service/AbocadoService.java
+++ b/src/main/java/software_capstone/backend/app/abocado/service/AbocadoService.java
@@ -31,7 +31,7 @@ public class AbocadoService {
                         .build());
 
         User user = userService.findUserById(userId);
-        user.updateDifficulty(request.difficulty());
+        user.completeOnboarding(request.difficulty());
         userRepository.save(user); // MongoDB는 JPA와 달리 영속성 컨텍스트가 없기에, 저장을 반영하려면 save 메서드 필요
     }
 }

--- a/src/main/java/software_capstone/backend/app/auth/document/Role.java
+++ b/src/main/java/software_capstone/backend/app/auth/document/Role.java
@@ -1,5 +1,0 @@
-package software_capstone.backend.app.auth.document;
-
-public enum Role {
-    USER, ADMIN
-}

--- a/src/main/java/software_capstone/backend/app/auth/document/User.java
+++ b/src/main/java/software_capstone/backend/app/auth/document/User.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
+import software_capstone.backend.app.abocado.document.Difficulty;
 import software_capstone.backend.global.document.BaseEntity;
 
 @Getter
@@ -19,4 +20,6 @@ public class User extends BaseEntity {
     private String name;
     private Role role;
     private boolean isProActive;
+
+    private Difficulty difficulty;
 }

--- a/src/main/java/software_capstone/backend/app/auth/service/AuthService.java
+++ b/src/main/java/software_capstone/backend/app/auth/service/AuthService.java
@@ -8,13 +8,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software_capstone.backend.app.auth.document.OAuthProvider;
 import software_capstone.backend.app.auth.document.RefreshToken;
-import software_capstone.backend.app.auth.document.Role;
-import software_capstone.backend.app.auth.document.User;
+import software_capstone.backend.app.user.document.Role;
+import software_capstone.backend.app.user.document.User;
 import software_capstone.backend.app.auth.dto.LoginRequest;
 import software_capstone.backend.app.auth.dto.TokenResponse;
 import software_capstone.backend.app.auth.jwt.TokenProvider;
 import software_capstone.backend.app.auth.repository.RefreshTokenRepository;
-import software_capstone.backend.app.auth.repository.UserRepository;
+import software_capstone.backend.app.user.repository.UserRepository;
 import software_capstone.backend.global.exception.ErrorMessage;
 import software_capstone.backend.global.exception.UnauthorizedException;
 

--- a/src/main/java/software_capstone/backend/app/user/document/Role.java
+++ b/src/main/java/software_capstone/backend/app/user/document/Role.java
@@ -1,0 +1,5 @@
+package software_capstone.backend.app.user.document;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/software_capstone/backend/app/user/document/User.java
+++ b/src/main/java/software_capstone/backend/app/user/document/User.java
@@ -23,4 +23,8 @@ public class User extends BaseEntity {
     private boolean isProActive;
 
     private Difficulty difficulty;
+
+    public void updateDifficulty(Difficulty difficulty) {
+        this.difficulty = difficulty;
+    }
 }

--- a/src/main/java/software_capstone/backend/app/user/document/User.java
+++ b/src/main/java/software_capstone/backend/app/user/document/User.java
@@ -1,4 +1,4 @@
-package software_capstone.backend.app.auth.document;
+package software_capstone.backend.app.user.document;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 import software_capstone.backend.app.abocado.document.Difficulty;
+import software_capstone.backend.app.auth.document.OAuthProvider;
 import software_capstone.backend.global.document.BaseEntity;
 
 @Getter

--- a/src/main/java/software_capstone/backend/app/user/document/User.java
+++ b/src/main/java/software_capstone/backend/app/user/document/User.java
@@ -8,6 +8,8 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import software_capstone.backend.app.abocado.document.Difficulty;
 import software_capstone.backend.app.auth.document.OAuthProvider;
 import software_capstone.backend.global.document.BaseEntity;
+import software_capstone.backend.global.exception.BadRequestException;
+import software_capstone.backend.global.exception.ErrorMessage;
 
 import java.time.LocalDateTime;
 
@@ -27,7 +29,14 @@ public class User extends BaseEntity {
     private Difficulty difficulty;
     private LocalDateTime onBoardedAt;
 
+    public boolean isOnboarded() {
+        return onBoardedAt != null;
+    }
+
     public void completeOnboarding(Difficulty difficulty) {
+        if (isOnboarded()) {
+            throw new BadRequestException(ErrorMessage.USER_ALREADY_ONBOARDED);
+        }
         this.difficulty = difficulty;
         this.onBoardedAt = LocalDateTime.now();
     }

--- a/src/main/java/software_capstone/backend/app/user/document/User.java
+++ b/src/main/java/software_capstone/backend/app/user/document/User.java
@@ -9,6 +9,8 @@ import software_capstone.backend.app.abocado.document.Difficulty;
 import software_capstone.backend.app.auth.document.OAuthProvider;
 import software_capstone.backend.global.document.BaseEntity;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @NoArgsConstructor
@@ -23,8 +25,10 @@ public class User extends BaseEntity {
     private boolean isProActive;
 
     private Difficulty difficulty;
+    private LocalDateTime onBoardedAt;
 
-    public void updateDifficulty(Difficulty difficulty) {
+    public void completeOnboarding(Difficulty difficulty) {
         this.difficulty = difficulty;
+        this.onBoardedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/software_capstone/backend/app/user/repository/UserRepository.java
+++ b/src/main/java/software_capstone/backend/app/user/repository/UserRepository.java
@@ -1,9 +1,9 @@
-package software_capstone.backend.app.auth.repository;
+package software_capstone.backend.app.user.repository;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 import software_capstone.backend.app.auth.document.OAuthProvider;
-import software_capstone.backend.app.auth.document.User;
+import software_capstone.backend.app.user.document.User;
 
 import java.util.Optional;
 

--- a/src/main/java/software_capstone/backend/app/user/service/UserService.java
+++ b/src/main/java/software_capstone/backend/app/user/service/UserService.java
@@ -1,0 +1,21 @@
+package software_capstone.backend.app.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import software_capstone.backend.app.user.document.User;
+import software_capstone.backend.app.user.repository.UserRepository;
+import software_capstone.backend.global.exception.ErrorMessage;
+import software_capstone.backend.global.exception.NotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    // 유저 검색 로직을 userService에서만 처리하여 일관적인 응답을 유지
+    public User findUserById(String id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
+++ b/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum ErrorMessage {
     // User
     USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
+    USER_ALREADY_ONBOARDED("이미 온보딩이 완료된 유저입니다."),
 
     // JWT
     INVALID_TOKEN("유효하지 않은 토큰입니다."),


### PR DESCRIPTION
## 📝 작업 내용
- 온보딩 시에 사용할 API를 작성하였습니다.
- 온보딩 시에는 새로운 아보카도가 생성되어야 하며, 동시에 난이도를 함께 설정해야 합니다.

## 🔄 변경 사항
- `user`, `auth` 간 패키지 범위를 확실하게 구분짓기 위해 패키지를 분리하였습니다.

## 🔗 관련 이슈
Closes #9 

## ✅ 체크리스트
- [x] 정상 동작 확인
- [x] 불필요한 코드 없음
- [ ] 리뷰 반영 완료
