### PR TITLE
Feature/#1: 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/software_capstone/backend/app/auth/controller/AuthController.java
+++ b/src/main/java/software_capstone/backend/app/auth/controller/AuthController.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,6 +47,13 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@RequestBody RefreshRequest request) {
         authService.logout(request.refreshToken());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "회원탈퇴", description = "리프레시 토큰과 유저를 삭제하여 회원 탈퇴합니다.")
+    @DeleteMapping("/{user-id}")
+    public ResponseEntity<Void> delete(@PathVariable("user-id") String userId) {
+        authService.deleteUser(userId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/software_capstone/backend/app/auth/dto/TokenResponse.java
+++ b/src/main/java/software_capstone/backend/app/auth/dto/TokenResponse.java
@@ -1,6 +1,7 @@
 package software_capstone.backend.app.auth.dto;
 
 public record TokenResponse(
+        String userId,
         String accessToken,
         String refreshToken,
         boolean isNewUser

--- a/src/main/java/software_capstone/backend/app/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/software_capstone/backend/app/auth/repository/RefreshTokenRepository.java
@@ -13,7 +13,7 @@ public interface RefreshTokenRepository extends MongoRepository<RefreshToken, St
 
     Optional<RefreshToken> findByUserIdAndDeviceInfo(String userId, String deviceInfo) ;
 
-    void deleteByUserId(String userId);         // 추후 회원탈퇴 시 사용할 예정
+    void deleteByUserId(String userId);
 
     void deleteByToken(String token);
 }

--- a/src/main/java/software_capstone/backend/app/auth/service/AuthService.java
+++ b/src/main/java/software_capstone/backend/app/auth/service/AuthService.java
@@ -16,6 +16,7 @@ import software_capstone.backend.app.auth.jwt.TokenProvider;
 import software_capstone.backend.app.auth.repository.RefreshTokenRepository;
 import software_capstone.backend.app.user.repository.UserRepository;
 import software_capstone.backend.global.exception.ErrorMessage;
+import software_capstone.backend.global.exception.NotFoundException;
 import software_capstone.backend.global.exception.UnauthorizedException;
 
 import java.time.LocalDateTime;
@@ -79,7 +80,7 @@ public class AuthService {
         saveRefreshToken(user.getId(), newRefreshToken, stored.getDeviceInfo());
 
         log.info("[Auth] 토큰 재발급 완료 - userId: {}", user.getId());
-        return new TokenResponse(newAccessToken, newRefreshToken, false);
+        return new TokenResponse(user.getId(), newAccessToken, newRefreshToken, false);
     }
 
     @Transactional
@@ -111,7 +112,7 @@ public class AuthService {
         saveRefreshToken(user.getId(), refreshToken, deviceInfo);
 
         log.info("[Auth] 토큰 발급 완료 - userId: {}", user.getId());
-        return new TokenResponse(accessToken, refreshToken, isNewUser);
+        return new TokenResponse(user.getId(), accessToken, refreshToken, isNewUser);
     }
 
     private void saveRefreshToken(String userId, String token, String deviceInfo) {
@@ -124,5 +125,15 @@ public class AuthService {
                 .deviceInfo(deviceInfo)
                 .expiresAt(LocalDateTime.now().plus(refreshTokenExpiration, ChronoUnit.MILLIS))
                 .build());
+    }
+
+    @Transactional
+    public void deleteUser(String userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND));
+
+        log.info("[Auth] 회원탈퇴 처리");
+        refreshTokenRepository.deleteByUserId(userId);
+        userRepository.deleteById(userId);
     }
 }

--- a/src/main/java/software_capstone/backend/app/auth/service/AuthService.java
+++ b/src/main/java/software_capstone/backend/app/auth/service/AuthService.java
@@ -98,7 +98,6 @@ public class AuthService {
                 .oauthId(oauthId)
                 .name(name)
                 .role(Role.USER)
-                .isProActive(false)
                 .build()));
 
         if (isNewUser) {

--- a/src/main/java/software_capstone/backend/app/user/document/User.java
+++ b/src/main/java/software_capstone/backend/app/user/document/User.java
@@ -24,8 +24,6 @@ public class User extends BaseEntity {
     private String oauthId;
     private String name;
     private Role role;
-    private boolean isProActive;
-
     private Difficulty difficulty;
     private LocalDateTime onBoardedAt;
 

--- a/src/main/java/software_capstone/backend/app/user/repository/UserRepository.java
+++ b/src/main/java/software_capstone/backend/app/user/repository/UserRepository.java
@@ -9,6 +9,5 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends MongoRepository<User, String> {
-
     Optional<User> findByOauthProviderAndOauthId(OAuthProvider oauthProvider, String oauthId);
 }


### PR DESCRIPTION
## 📝 작업 내용
- 회원 탈퇴 기능을 구현했습니다.
- `User` 엔티티에서 불필요한 `isProActive` 필드를 삭제하였습니다.
- `TokenResponse`에서 userId를 함께 반환하도록 수정하였습니다.

## 🔄 변경 사항
- `AuthService`에 `deleteUser` 메서드 작성
- `User` 엔티티에서 `isProActive` 삭제
- `TokenResponse`에 `userId` 추가

## 🔗 관련 이슈
Closes #1

## ✅ 체크리스트
- [x] 정상 동작 확인
- [x] 불필요한 코드 없음
- [ ] 리뷰 반영 완료
