### PR TITLE
Feature/#20: 보관함 조회 API 구현

### DIFF
--- a/src/main/java/software_capstone/backend/app/store/controller/ShopController.java
+++ b/src/main/java/software_capstone/backend/app/store/controller/ShopController.java
@@ -3,11 +3,10 @@ package software_capstone.backend.app.store.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import software_capstone.backend.app.store.document.category.ItemCategory;
+import software_capstone.backend.app.store.dto.request.PurchaseRequest;
+import software_capstone.backend.app.store.dto.response.PurchaseResponse;
 import software_capstone.backend.app.store.dto.response.ShopItemResponse;
 import software_capstone.backend.app.store.service.ShopService;
 
@@ -27,5 +26,14 @@ public class ShopController implements ShopControllerDocs {
             @RequestParam(required = false) ItemCategory category
     ) {
         return ResponseEntity.ok(shopService.getItems(userId, category));
+    }
+
+    @Override
+    @PostMapping("/items/purchase")
+    public ResponseEntity<PurchaseResponse> purchaseItem(
+            @AuthenticationPrincipal String userId,
+            @RequestBody PurchaseRequest request
+    ) {
+        return ResponseEntity.ok(shopService.purchaseItem(userId, request));
     }
 }

--- a/src/main/java/software_capstone/backend/app/store/controller/ShopController.java
+++ b/src/main/java/software_capstone/backend/app/store/controller/ShopController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import software_capstone.backend.app.store.document.category.ItemCategory;
-import software_capstone.backend.app.store.dto.ShopItemResponse;
+import software_capstone.backend.app.store.dto.response.ShopItemResponse;
 import software_capstone.backend.app.store.service.ShopService;
 
 import java.util.List;

--- a/src/main/java/software_capstone/backend/app/store/controller/ShopController.java
+++ b/src/main/java/software_capstone/backend/app/store/controller/ShopController.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import software_capstone.backend.app.store.document.category.ItemCategory;
 import software_capstone.backend.app.store.dto.request.PurchaseRequest;
+import software_capstone.backend.app.store.dto.response.InventoryResponse;
 import software_capstone.backend.app.store.dto.response.PurchaseResponse;
 import software_capstone.backend.app.store.dto.response.ShopItemResponse;
 import software_capstone.backend.app.store.service.ShopService;
@@ -35,5 +36,13 @@ public class ShopController implements ShopControllerDocs {
             @RequestBody PurchaseRequest request
     ) {
         return ResponseEntity.ok(shopService.purchaseItem(userId, request));
+    }
+
+    @Override
+    @GetMapping("/inventory")
+    public ResponseEntity<List<InventoryResponse>> getInventory(
+            @AuthenticationPrincipal String userId
+    ) {
+        return ResponseEntity.ok(shopService.getInventory(userId));
     }
 }

--- a/src/main/java/software_capstone/backend/app/store/controller/ShopControllerDocs.java
+++ b/src/main/java/software_capstone/backend/app/store/controller/ShopControllerDocs.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import software_capstone.backend.app.store.document.category.ItemCategory;
 import software_capstone.backend.app.store.dto.request.PurchaseRequest;
+import software_capstone.backend.app.store.dto.response.InventoryResponse;
 import software_capstone.backend.app.store.dto.response.PurchaseResponse;
 import software_capstone.backend.app.store.dto.response.ShopItemResponse;
 
@@ -57,4 +58,22 @@ public interface ShopControllerDocs {
             @ApiResponse(responseCode = "404", description = "유저 또는 아이템을 찾을 수 없음")
     })
     ResponseEntity<PurchaseResponse> purchaseItem(String userId, PurchaseRequest request);
+
+    @Operation(
+            summary = "보관함 조회",
+            description =
+                    """
+                    유저의 보관함 아이템 목록을 조회합니다.
+                    
+                    보유 수량이 0인 아이템은 포함되지 않습니다.
+                    
+                    토큰으로 받아온 유저가 존재하지 않다면 에러가 발생합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "보관함 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "토큰을 담아 요청하지 않음"),
+            @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
+    })
+    ResponseEntity<List<InventoryResponse>> getInventory(String userId);
 }

--- a/src/main/java/software_capstone/backend/app/store/controller/ShopControllerDocs.java
+++ b/src/main/java/software_capstone/backend/app/store/controller/ShopControllerDocs.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import software_capstone.backend.app.store.document.category.ItemCategory;
+import software_capstone.backend.app.store.dto.request.PurchaseRequest;
+import software_capstone.backend.app.store.dto.response.PurchaseResponse;
 import software_capstone.backend.app.store.dto.response.ShopItemResponse;
 
 import java.util.List;
@@ -32,4 +34,27 @@ public interface ShopControllerDocs {
             @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
     })
     ResponseEntity<List<ShopItemResponse>> getItems(String userId, ItemCategory category);
+
+    @Operation(
+            summary = "상점 아이템 구매",
+            description =
+                    """
+                    상점 아이템을 구매합니다.
+                    
+                    캐시가 부족할 경우 에러가 발생합니다.
+                    
+                    출시되지 않은 아이템은 구매할 수 없습니다.
+                    
+                    구매 성공 시 보관함에 아이템이 추가되고 구매 내역이 저장됩니다.
+                    
+                    토큰으로 받아온 유저가 존재하지 않다면 에러가 발생합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "아이템 구매 성공"),
+            @ApiResponse(responseCode = "400", description = "캐시 부족"),
+            @ApiResponse(responseCode = "403", description = "토큰을 담아 요청하지 않음"),
+            @ApiResponse(responseCode = "404", description = "유저 또는 아이템을 찾을 수 없음")
+    })
+    ResponseEntity<PurchaseResponse> purchaseItem(String userId, PurchaseRequest request);
 }

--- a/src/main/java/software_capstone/backend/app/store/controller/ShopControllerDocs.java
+++ b/src/main/java/software_capstone/backend/app/store/controller/ShopControllerDocs.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import software_capstone.backend.app.store.document.category.ItemCategory;
-import software_capstone.backend.app.store.dto.ShopItemResponse;
+import software_capstone.backend.app.store.dto.response.ShopItemResponse;
 
 import java.util.List;
 

--- a/src/main/java/software_capstone/backend/app/store/document/PurchaseHistory.java
+++ b/src/main/java/software_capstone/backend/app/store/document/PurchaseHistory.java
@@ -1,0 +1,18 @@
+package software_capstone.backend.app.store.document;
+
+import lombok.*;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import software_capstone.backend.global.document.BaseEntity;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Document(collection = "purchase_histories")
+public class PurchaseHistory extends BaseEntity {
+    @Indexed
+    private String userId;
+    private String itemId;
+    private int price;
+}

--- a/src/main/java/software_capstone/backend/app/store/document/UserInventory.java
+++ b/src/main/java/software_capstone/backend/app/store/document/UserInventory.java
@@ -1,0 +1,23 @@
+package software_capstone.backend.app.store.document;
+
+import lombok.*;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import software_capstone.backend.global.document.BaseEntity;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Document(collection = "user_inventories")
+public class UserInventory extends BaseEntity {
+    @Indexed
+    private String userId;
+    private String itemId;
+    @Builder.Default
+    private int quantity = 0;
+
+    public void increaseQuantity() {
+        this.quantity++;
+    }
+}

--- a/src/main/java/software_capstone/backend/app/store/dto/request/PurchaseRequest.java
+++ b/src/main/java/software_capstone/backend/app/store/dto/request/PurchaseRequest.java
@@ -1,0 +1,10 @@
+package software_capstone.backend.app.store.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PurchaseRequest {
+    private String itemId;
+}

--- a/src/main/java/software_capstone/backend/app/store/dto/response/InventoryResponse.java
+++ b/src/main/java/software_capstone/backend/app/store/dto/response/InventoryResponse.java
@@ -1,0 +1,30 @@
+package software_capstone.backend.app.store.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import software_capstone.backend.app.store.document.ShopItem;
+import software_capstone.backend.app.store.document.UserInventory;
+import software_capstone.backend.app.store.document.category.ItemCategory;
+import software_capstone.backend.app.store.document.category.ItemGrade;
+
+@Getter
+@Builder
+public class InventoryResponse {
+    private String inventoryId;
+    private String itemId;
+    private String itemName;
+    private ItemCategory category;
+    private ItemGrade grade;
+    private int quantity;
+
+    public static InventoryResponse of(UserInventory inventory, ShopItem item) {
+        return InventoryResponse.builder()
+                .inventoryId(inventory.getId())
+                .itemId(item.getId())
+                .itemName(item.getName())
+                .category(item.getCategory())
+                .grade(item.getGrade())
+                .quantity(inventory.getQuantity())
+                .build();
+    }
+}

--- a/src/main/java/software_capstone/backend/app/store/dto/response/PurchaseResponse.java
+++ b/src/main/java/software_capstone/backend/app/store/dto/response/PurchaseResponse.java
@@ -1,0 +1,21 @@
+package software_capstone.backend.app.store.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import software_capstone.backend.app.store.document.ShopItem;
+
+@Getter
+@Builder
+public class PurchaseResponse {
+    private String itemId;
+    private String itemName;
+    private int remainingCash;
+
+    public static PurchaseResponse of(ShopItem item, int remainingCash) {
+        return PurchaseResponse.builder()
+                .itemId(item.getId())
+                .itemName(item.getName())
+                .remainingCash(remainingCash)
+                .build();
+    }
+}

--- a/src/main/java/software_capstone/backend/app/store/dto/response/ShopItemResponse.java
+++ b/src/main/java/software_capstone/backend/app/store/dto/response/ShopItemResponse.java
@@ -1,4 +1,4 @@
-package software_capstone.backend.app.store.dto;
+package software_capstone.backend.app.store.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/software_capstone/backend/app/store/repository/PurchaseHistoryRepository.java
+++ b/src/main/java/software_capstone/backend/app/store/repository/PurchaseHistoryRepository.java
@@ -1,0 +1,7 @@
+package software_capstone.backend.app.store.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import software_capstone.backend.app.store.document.PurchaseHistory;
+
+public interface PurchaseHistoryRepository extends MongoRepository<PurchaseHistory, String> {
+}

--- a/src/main/java/software_capstone/backend/app/store/repository/ShopItemRepository.java
+++ b/src/main/java/software_capstone/backend/app/store/repository/ShopItemRepository.java
@@ -5,10 +5,14 @@ import software_capstone.backend.app.store.document.category.ItemCategory;
 import software_capstone.backend.app.store.document.ShopItem;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ShopItemRepository extends MongoRepository<ShopItem, String> {
 
+    // 전체 출시 아이템 조회
     List<ShopItem> findByIsReleasedTrue();
-
+    // 카테고리별 출시 아이템 조회
     List<ShopItem> findByCategoryAndIsReleasedTrue(ItemCategory category);
+    // 단건 출시 아이템 조회 (구새 시 사용)
+    Optional<ShopItem> findByIdAndIsReleasedTrue(String id);
 }

--- a/src/main/java/software_capstone/backend/app/store/repository/ShopItemRepository.java
+++ b/src/main/java/software_capstone/backend/app/store/repository/ShopItemRepository.java
@@ -15,4 +15,6 @@ public interface ShopItemRepository extends MongoRepository<ShopItem, String> {
     List<ShopItem> findByCategoryAndIsReleasedTrue(ItemCategory category);
     // 단건 출시 아이템 조회 (구새 시 사용)
     Optional<ShopItem> findByIdAndIsReleasedTrue(String id);
+    // id 리스트 조회
+    List<ShopItem> findByIdIn(List<String> ids);
 }

--- a/src/main/java/software_capstone/backend/app/store/repository/UserInventoryRepository.java
+++ b/src/main/java/software_capstone/backend/app/store/repository/UserInventoryRepository.java
@@ -1,0 +1,12 @@
+package software_capstone.backend.app.store.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import software_capstone.backend.app.store.document.UserInventory;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserInventoryRepository extends MongoRepository<UserInventory, String> {
+    Optional<UserInventory> findByUserIdAndItemId(String userId, String itemId);
+    List<UserInventory> findByUserId(String userId);
+}

--- a/src/main/java/software_capstone/backend/app/store/service/ShopService.java
+++ b/src/main/java/software_capstone/backend/app/store/service/ShopService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software_capstone.backend.app.store.document.category.ItemCategory;
 import software_capstone.backend.app.store.document.ShopItem;
-import software_capstone.backend.app.store.dto.ShopItemResponse;
+import software_capstone.backend.app.store.dto.response.ShopItemResponse;
 import software_capstone.backend.app.store.repository.ShopItemRepository;
 import software_capstone.backend.app.user.service.UserService;
 

--- a/src/main/java/software_capstone/backend/app/store/service/ShopService.java
+++ b/src/main/java/software_capstone/backend/app/store/service/ShopService.java
@@ -8,6 +8,7 @@ import software_capstone.backend.app.store.document.UserInventory;
 import software_capstone.backend.app.store.document.category.ItemCategory;
 import software_capstone.backend.app.store.document.ShopItem;
 import software_capstone.backend.app.store.dto.request.PurchaseRequest;
+import software_capstone.backend.app.store.dto.response.InventoryResponse;
 import software_capstone.backend.app.store.dto.response.PurchaseResponse;
 import software_capstone.backend.app.store.dto.response.ShopItemResponse;
 import software_capstone.backend.app.store.repository.PurchaseHistoryRepository;
@@ -19,6 +20,8 @@ import software_capstone.backend.global.exception.ErrorMessage;
 import software_capstone.backend.global.exception.NotFoundException;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -67,5 +70,24 @@ public class ShopService {
                 .build());
 
         return PurchaseResponse.of(item, user.getCash());
+    }
+
+    @Transactional(readOnly = true)
+    public List<InventoryResponse> getInventory(String userId) {
+        userService.findUserById(userId);
+
+        List<UserInventory> inventories = userInventoryRepository.findByUserId(userId);
+
+        List<String> itemIds = inventories.stream()
+                .map(UserInventory::getItemId)
+                .toList();
+
+        Map<String, ShopItem> itemMap = shopItemRepository.findByIdIn(itemIds).stream()
+                .collect(Collectors.toMap(ShopItem::getId, item -> item));
+
+        return inventories.stream()
+                .filter(inventory -> itemMap.containsKey(inventory.getItemId()))
+                .map(inventory -> InventoryResponse.of(inventory, itemMap.get(inventory.getItemId())))
+                .toList();
     }
 }

--- a/src/main/java/software_capstone/backend/app/store/service/ShopService.java
+++ b/src/main/java/software_capstone/backend/app/store/service/ShopService.java
@@ -3,11 +3,20 @@ package software_capstone.backend.app.store.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software_capstone.backend.app.store.document.PurchaseHistory;
+import software_capstone.backend.app.store.document.UserInventory;
 import software_capstone.backend.app.store.document.category.ItemCategory;
 import software_capstone.backend.app.store.document.ShopItem;
+import software_capstone.backend.app.store.dto.request.PurchaseRequest;
+import software_capstone.backend.app.store.dto.response.PurchaseResponse;
 import software_capstone.backend.app.store.dto.response.ShopItemResponse;
+import software_capstone.backend.app.store.repository.PurchaseHistoryRepository;
 import software_capstone.backend.app.store.repository.ShopItemRepository;
+import software_capstone.backend.app.store.repository.UserInventoryRepository;
+import software_capstone.backend.app.user.document.User;
 import software_capstone.backend.app.user.service.UserService;
+import software_capstone.backend.global.exception.ErrorMessage;
+import software_capstone.backend.global.exception.NotFoundException;
 
 import java.util.List;
 
@@ -15,6 +24,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ShopService {
     private final ShopItemRepository shopItemRepository;
+    private final UserInventoryRepository userInventoryRepository;
+    private final PurchaseHistoryRepository purchaseHistoryRepository;
     private final UserService userService;
 
     @Transactional(readOnly = true)
@@ -28,5 +39,33 @@ public class ShopService {
         return items.stream()
                 .map(ShopItemResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public PurchaseResponse purchaseItem(String userId, PurchaseRequest request) {
+        User user = userService.findUserById(userId);
+
+        ShopItem item = shopItemRepository.findByIdAndIsReleasedTrue(request.getItemId())
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.ITEM_NOT_FOUND));
+
+        user.deductCash(item.getPrice());
+        userService.save(user);
+
+        UserInventory inventory = userInventoryRepository
+                .findByUserIdAndItemId(userId, item.getId())
+                .orElseGet(() -> UserInventory.builder()
+                        .userId(userId)
+                        .itemId(item.getId())
+                        .build());
+        inventory.increaseQuantity();
+        userInventoryRepository.save(inventory);
+
+        purchaseHistoryRepository.save(PurchaseHistory.builder()
+                .userId(userId)
+                .itemId(item.getId())
+                .price(item.getPrice())
+                .build());
+
+        return PurchaseResponse.of(item, user.getCash());
     }
 }

--- a/src/main/java/software_capstone/backend/app/user/document/User.java
+++ b/src/main/java/software_capstone/backend/app/user/document/User.java
@@ -25,6 +25,7 @@ public class User extends BaseEntity {
     private Role role;
     private Difficulty difficulty;
     private LocalDateTime onBoardedAt;
+    private int cash;
 
     public boolean isOnboarded() {
         return onBoardedAt != null;
@@ -36,5 +37,12 @@ public class User extends BaseEntity {
         }
         this.difficulty = difficulty;
         this.onBoardedAt = LocalDateTime.now();
+    }
+
+    public void deductCash(int amount) {
+        if (this.cash < amount) {
+            throw new BadRequestException(ErrorMessage.INSUFFICIENT_CASH);
+        }
+        this.cash -= amount;
     }
 }

--- a/src/main/java/software_capstone/backend/app/user/service/UserService.java
+++ b/src/main/java/software_capstone/backend/app/user/service/UserService.java
@@ -18,4 +18,8 @@ public class UserService {
         return userRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND));
     }
+
+    public User save(User user) {
+        return userRepository.save(user);
+    }
 }

--- a/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
+++ b/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
@@ -14,8 +14,10 @@ public enum ErrorMessage {
     REFRESH_TOKEN_NOT_ALLOWED("리프레시 토큰으로는 접근할 수 없습니다."),
 
     // Avocado
-    CURRENT_ACTIVE_AVOCADO_NOT_FOUND("현재 활성화중인 아보카도를 찾을 수 없습니다.");
+    CURRENT_ACTIVE_AVOCADO_NOT_FOUND("현재 활성화중인 아보카도를 찾을 수 없습니다."),
 
+    // store
+    INSUFFICIENT_CASH("캐시가 부족합니다.");
     private final String message;
 
     ErrorMessage(String message) {

--- a/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
+++ b/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
@@ -17,6 +17,7 @@ public enum ErrorMessage {
     CURRENT_ACTIVE_AVOCADO_NOT_FOUND("현재 활성화중인 아보카도를 찾을 수 없습니다."),
 
     // store
+    ITEM_NOT_FOUND("아이템을 찾을 수 없습니다."),
     INSUFFICIENT_CASH("캐시가 부족합니다.");
     private final String message;
 


### PR DESCRIPTION
## 📝 작업 내용
- 유저 보관함 아이템 목록 조회 API 구현
- 보관함 아이템 ID 목록으로 아이템 정보 일괄 조회

## 🔄 변경 사항
- InventoryResponse 추가
- ShopItemRepository findByIdIn 메서드 추가
- ShopService 보관함 조회 로직 추가
- ShopController GET /shop/inventory API 추가
- ShopControllerDocs 보관함 조회 Swagger 명세 추가

## 🔗 관련 이슈
Closes #20

## ✅ 체크리스트
- [ ] 정상 동작 확인
- [ ] 불필요한 코드 없음
- [ ] 리뷰 반영 완료
