### PR TITLE
Feature/#30: 플래시카드 학습 관련 기능 구현

### DIFF
--- a/src/main/java/software_capstone/backend/app/flashcard/controller/FlashcardController.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/controller/FlashcardController.java
@@ -1,0 +1,101 @@
+package software_capstone.backend.app.flashcard.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import software_capstone.backend.app.auth.jwt.TokenProvider;
+import software_capstone.backend.app.flashcard.dto.FlashcardResponse;
+import software_capstone.backend.app.flashcard.dto.PronunciationResponse;
+import software_capstone.backend.app.flashcard.service.FlashcardService;
+
+@Tag(name = "Flashcard", description = "플래시카드 학습 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/flashcard")
+public class FlashcardController {
+
+    private final FlashcardService flashcardService;
+
+    @Operation(
+            summary = "오늘의 플래시카드 조회",
+            description = """
+                    오늘의 플래시카드 단어 목록을 조회합니다.
+
+                    유저의 난이도에 맞는 단어 5개를 AI 서버에서 생성하여 반환합니다.
+
+                    학습 세션이 생성되며, 반환된 sessionId는 이후 학습 완료 요청에 사용됩니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "플래시카드 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "온보딩이 완료되지 않은 유저"),
+            @ApiResponse(responseCode = "403", description = "토큰을 담아 요청하지 않음"),
+            @ApiResponse(responseCode = "404", description = "유저가 존재하지 않음")
+    })
+    @GetMapping
+    public ResponseEntity<FlashcardResponse> getFlashcard(
+            @AuthenticationPrincipal TokenProvider.AuthUser authUser
+    ) {
+        return ResponseEntity.ok(flashcardService.getFlashcard(authUser.userId()));
+    }
+
+    @Operation(
+            summary = "플래시카드 학습 완료",
+            description = """
+                    플래시카드 학습을 완료 처리합니다.
+
+                    조회 시 반환된 sessionId를 경로에 담아 요청해야 합니다.
+
+                    퀴즈까지 완료된 경우 학습 세션 전체가 COMPLETED 상태로 변경됩니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "학습 완료 처리 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 완료된 세션이거나 세션 소유자가 아님"),
+            @ApiResponse(responseCode = "403", description = "토큰을 담아 요청하지 않음"),
+            @ApiResponse(responseCode = "404", description = "세션이 존재하지 않음")
+    })
+    @PostMapping("/complete/{session-id}")
+    public ResponseEntity<Void> completeFlashcard(
+            @AuthenticationPrincipal TokenProvider.AuthUser authUser,
+            @PathVariable("session-id") String sessionId
+    ) {
+        flashcardService.completeFlashcard(authUser.userId(), sessionId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "발음 판정",
+            description = """
+                    녹음된 오디오 파일을 AI 서버에 전송하여 발음을 판정합니다.
+
+                    multipart/form-data 형식으로 오디오 파일(audio_file)과 목표 단어(target_word)를 함께 전송해야 합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "발음 판정 성공"),
+            @ApiResponse(responseCode = "400", description = "오디오 파일이 비어있음"),
+            @ApiResponse(responseCode = "403", description = "토큰을 담아 요청하지 않음")
+    })
+    @PostMapping(value = "/pronunciation", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PronunciationResponse> getPronunciationFeedback(
+            @AuthenticationPrincipal String userId,
+            @RequestPart MultipartFile audioFile,
+            @RequestParam String targetWord
+    ) {
+        return ResponseEntity.ok(flashcardService.getPronunciationFeedback(userId, audioFile, targetWord));
+    }
+}

--- a/src/main/java/software_capstone/backend/app/flashcard/controller/FlashcardController.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/controller/FlashcardController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import software_capstone.backend.app.auth.jwt.TokenProvider;
+import software_capstone.backend.app.flashcard.dto.FlashcardCompleteResponse;
 import software_capstone.backend.app.flashcard.dto.FlashcardResponse;
 import software_capstone.backend.app.flashcard.dto.PronunciationResponse;
 import software_capstone.backend.app.flashcard.service.FlashcardService;
@@ -69,12 +70,11 @@ public class FlashcardController {
             @ApiResponse(responseCode = "404", description = "세션이 존재하지 않음")
     })
     @PostMapping("/complete/{session-id}")
-    public ResponseEntity<Void> completeFlashcard(
+    public ResponseEntity<FlashcardCompleteResponse> completeFlashcard(
             @AuthenticationPrincipal TokenProvider.AuthUser authUser,
             @PathVariable("session-id") String sessionId
     ) {
-        flashcardService.completeFlashcard(authUser.userId(), sessionId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(flashcardService.completeFlashcard(authUser.userId(), sessionId));
     }
 
     @Operation(

--- a/src/main/java/software_capstone/backend/app/flashcard/controller/FlashcardController.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/controller/FlashcardController.java
@@ -78,6 +78,28 @@ public class FlashcardController {
     }
 
     @Operation(
+            summary = "TTS 생성",
+            description = """
+                    플래시 카드 단어를 AI 서버에 전송하여 음성 오디오를 생성합니다.
+
+                    쿼리 파라미터로 변환할 텍스트(text)를 전달하면 audio/mpeg 형식의 오디오 데이터를 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "TTS 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "텍스트가 비어있음")
+    })
+    @PostMapping("/tts")
+    public ResponseEntity<byte[]> createTts(
+            @RequestParam String text
+    ) {
+        byte[] audio = flashcardService.createTts(text);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("audio/mpeg"))
+                .body(audio);
+    }
+
+    @Operation(
             summary = "발음 판정",
             description = """
                     녹음된 오디오 파일을 AI 서버에 전송하여 발음을 판정합니다.

--- a/src/main/java/software_capstone/backend/app/flashcard/controller/FlashcardController.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/controller/FlashcardController.java
@@ -114,10 +114,10 @@ public class FlashcardController {
     })
     @PostMapping(value = "/pronunciation", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<PronunciationResponse> getPronunciationFeedback(
-            @AuthenticationPrincipal String userId,
+            @AuthenticationPrincipal TokenProvider.AuthUser authUser,
             @RequestPart MultipartFile audioFile,
             @RequestParam String targetWord
     ) {
-        return ResponseEntity.ok(flashcardService.getPronunciationFeedback(userId, audioFile, targetWord));
+        return ResponseEntity.ok(flashcardService.getPronunciationFeedback(authUser.userId(), audioFile, targetWord));
     }
 }

--- a/src/main/java/software_capstone/backend/app/flashcard/dto/FlashcardCompleteResponse.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/dto/FlashcardCompleteResponse.java
@@ -1,0 +1,3 @@
+package software_capstone.backend.app.flashcard.dto;
+
+public record FlashcardCompleteResponse(int totalWordsToday) {}

--- a/src/main/java/software_capstone/backend/app/flashcard/dto/FlashcardResponse.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/dto/FlashcardResponse.java
@@ -1,0 +1,13 @@
+package software_capstone.backend.app.flashcard.dto;
+
+import java.util.List;
+
+public record FlashcardResponse(String sessionId, List<WordItem> words) {
+
+    public record WordItem(
+            String word,
+            String partOfSpeech,
+            String pronunciation,
+            String meaning
+    ) {}
+}

--- a/src/main/java/software_capstone/backend/app/flashcard/dto/LangChainFlashcardResponse.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/dto/LangChainFlashcardResponse.java
@@ -1,0 +1,18 @@
+package software_capstone.backend.app.flashcard.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record LangChainFlashcardResponse(List<WordItem> words) {
+
+    public record WordItem(
+            String word,
+
+            @JsonProperty("part_of_speech")
+            String partOfSpeech,
+
+            String pronunciation,
+            String meaning
+    ) {}
+}

--- a/src/main/java/software_capstone/backend/app/flashcard/dto/PronunciationResponse.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/dto/PronunciationResponse.java
@@ -1,0 +1,13 @@
+package software_capstone.backend.app.flashcard.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record PronunciationResponse(
+        @JsonProperty("is_correct")
+        boolean isCorrect,
+
+        @JsonProperty("recognized_text")
+        String recognizedText,
+
+        String feedback
+) {}

--- a/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardClient.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardClient.java
@@ -1,0 +1,63 @@
+package software_capstone.backend.app.flashcard.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import software_capstone.backend.app.abocado.document.Difficulty;
+import software_capstone.backend.app.flashcard.dto.LangChainFlashcardResponse;
+import software_capstone.backend.app.flashcard.dto.PronunciationResponse;
+import software_capstone.backend.global.exception.BadRequestException;
+import software_capstone.backend.global.exception.ErrorMessage;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FlashcardClient {
+
+    private final WebClient webClient;
+
+    @Value("${langchain.base-url}")
+    private String langchainBaseUrl;
+
+    public LangChainFlashcardResponse generateWords(Difficulty difficulty) {
+        log.info("[FlashcardClient] 단어 생성 요청 - difficulty: {}", difficulty);
+
+        return webClient.post()
+                .uri(langchainBaseUrl + "/flashcard")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("level", difficulty.name()))
+                .retrieve()
+                .onStatus(status -> status.isError(), res ->
+                        res.bodyToMono(String.class)
+                                .map(body -> new BadRequestException(ErrorMessage.LANGCHAIN_SERVER_ERROR)))
+                .bodyToMono(LangChainFlashcardResponse.class)
+                .block();
+    }
+
+    public PronunciationResponse getPronunciationFeedback(MultipartFile audioFile, String targetWord) {
+        log.info("[FlashcardClient] 발음 판정 요청 - targetWord: {}", targetWord);
+
+        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+        builder.part("audio_file", audioFile.getResource());
+        builder.part("target_word", targetWord);
+
+        return webClient.post()
+                .uri(langchainBaseUrl + "/flashcard/pronunciation")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(builder.build()))
+                .retrieve()
+                .onStatus(status -> status.isError(), res ->
+                        res.bodyToMono(String.class)
+                                .map(body -> new BadRequestException(ErrorMessage.LANGCHAIN_SERVER_ERROR)))
+                .bodyToMono(PronunciationResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardClient.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardClient.java
@@ -42,6 +42,21 @@ public class FlashcardClient {
                 .block();
     }
 
+    public byte[] createTts(String text) {
+        log.info("[FlashcardClient] TTS 생성 요청 - text: {}", text);
+
+        return webClient.post()
+                .uri(langchainBaseUrl + "/flashcard/tts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of("text", text))
+                .retrieve()
+                .onStatus(status -> status.isError(), res ->
+                        res.bodyToMono(String.class)
+                                .map(body -> new BadRequestException(ErrorMessage.LANGCHAIN_SERVER_ERROR)))
+                .bodyToMono(byte[].class)
+                .block();
+    }
+
     public PronunciationResponse getPronunciationFeedback(MultipartFile audioFile, String targetWord) {
         log.info("[FlashcardClient] 발음 판정 요청 - targetWord: {}", targetWord);
 

--- a/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardClient.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardClient.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
-import software_capstone.backend.app.abocado.document.Difficulty;
+import software_capstone.backend.app.user.document.Difficulty;
 import software_capstone.backend.app.flashcard.dto.LangChainFlashcardResponse;
 import software_capstone.backend.app.flashcard.dto.PronunciationResponse;
 import software_capstone.backend.global.exception.BadRequestException;

--- a/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardService.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardService.java
@@ -1,0 +1,100 @@
+package software_capstone.backend.app.flashcard.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software_capstone.backend.app.flashcard.dto.FlashcardResponse;
+import software_capstone.backend.app.flashcard.dto.LangChainFlashcardResponse;
+import software_capstone.backend.app.flashcard.dto.PronunciationResponse;
+import software_capstone.backend.app.learning.document.Flashcard;
+import software_capstone.backend.app.learning.document.LearningSession;
+import software_capstone.backend.app.learning.repository.LearningSessionRepository;
+import software_capstone.backend.app.user.document.User;
+import software_capstone.backend.app.user.service.UserService;
+import software_capstone.backend.global.exception.BadRequestException;
+import software_capstone.backend.global.exception.ErrorMessage;
+import software_capstone.backend.global.exception.NotFoundException;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FlashcardService {
+
+    private final FlashcardClient flashcardClient;
+    private final UserService userService;
+    private final LearningSessionRepository learningSessionRepository;
+
+    // 플래시카드 단어 목록 조회
+    public FlashcardResponse getFlashcard(String userId) {
+        User user = userService.findUserById(userId);
+
+        if (user.getDifficulty() == null) {
+            throw new BadRequestException(ErrorMessage.USER_NOT_ONBOARDED);
+        }
+
+        log.info("[Flashcard] 단어 생성 요청 - userId: {}, difficulty: {}", userId, user.getDifficulty());
+
+        LangChainFlashcardResponse langChainResponse = flashcardClient.generateWords(user.getDifficulty());
+
+        List<Flashcard> flashcards = langChainResponse.words().stream()
+                .map(w -> Flashcard.builder()
+                        .word(w.word())
+                        .partOfSpeech(w.partOfSpeech())
+                        .pronunciation(w.pronunciation())
+                        .meaning(w.meaning())
+                        .build())
+                .toList();
+
+        LearningSession saved = learningSessionRepository.save(
+                LearningSession.builder()
+                        .userId(userId)
+                        .date(LocalDate.now())
+                        .difficulty(user.getDifficulty())
+                        .flashcards(flashcards)
+                        .build()
+        );
+
+        log.info("[Flashcard] 학습 세션 생성 완료 - userId: {}", userId);
+
+        List<FlashcardResponse.WordItem> wordItems = langChainResponse.words().stream()
+                .map(w -> new FlashcardResponse.WordItem(w.word(), w.partOfSpeech(), w.pronunciation(), w.meaning()))
+                .toList();
+
+        return new FlashcardResponse(saved.getId(), wordItems);
+    }
+
+    // 플래시카드 학습 완료 상태로 변경
+    public void completeFlashcard(String userId, String sessionId) {
+        LearningSession session = learningSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.LEARNING_SESSION_NOT_FOUND));
+
+        if (!session.getUserId().equals(userId)) {
+            throw new BadRequestException(ErrorMessage.SESSION_USER_MISMATCH);
+        }
+
+        if (session.isFlashcardsCompleted()) {
+            throw new BadRequestException(ErrorMessage.ALREADY_COMPLETED_SESSION);
+        }
+
+        session.completeFlashcards();
+        learningSessionRepository.save(session);
+
+        log.info("[Flashcard] 학습 완료 처리 - userId: {}, sessionId: {}", userId, sessionId);
+    }
+
+    // 발음 판정
+    public PronunciationResponse getPronunciationFeedback(
+            String userId, MultipartFile audioFile, String targetWord) {
+        if (audioFile == null || audioFile.isEmpty()) {
+            throw new BadRequestException(ErrorMessage.EMPTY_AUDIO_FILE);
+        }
+
+        log.info("[Flashcard] 발음 판정 요청 - userId: {}, targetWord: {}", userId, targetWord);
+
+        return flashcardClient.getPronunciationFeedback(audioFile, targetWord);
+    }
+}

--- a/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardService.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardService.java
@@ -11,6 +11,7 @@ import software_capstone.backend.app.flashcard.dto.PronunciationResponse;
 import software_capstone.backend.app.learning.document.Flashcard;
 import software_capstone.backend.app.learning.document.LearningSession;
 import software_capstone.backend.app.learning.repository.LearningSessionRepository;
+import software_capstone.backend.app.user.document.Difficulty;
 import software_capstone.backend.app.user.document.User;
 import software_capstone.backend.app.user.service.UserService;
 import software_capstone.backend.global.exception.BadRequestException;
@@ -19,7 +20,6 @@ import software_capstone.backend.global.exception.NotFoundException;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -38,25 +38,23 @@ public class FlashcardService {
             throw new BadRequestException(ErrorMessage.USER_NOT_ONBOARDED);
         }
 
-        // 오늘 미완료 세션이 있으면 기존 세션 반환
-        Optional<LearningSession> existingSession = learningSessionRepository
-                .findByUserIdAndDateAndFlashcardsCompletedFalse(userId, LocalDate.now());
+        return learningSessionRepository
+                .findByUserIdAndDateAndFlashcardsCompletedFalse(userId, LocalDate.now())
+                .map(this::toFlashcardResponse)
+                .orElseGet(() -> createFlashcardSession(userId, user.getDifficulty()));
+    }
 
-        if (existingSession.isPresent()) {
-            LearningSession session = existingSession.get();
-            log.info("[Flashcard] 기존 미완료 세션 반환 - userId: {}, sessionId: {}", userId, session.getId());
+    // 기존 미완료 세션 → 응답 변환
+    private FlashcardResponse toFlashcardResponse(LearningSession session) {
+        log.info("[Flashcard] 기존 미완료 세션 반환 - userId: {}, sessionId: {}", session.getUserId(), session.getId());
+        return new FlashcardResponse(session.getId(), toWordItems(session.getFlashcards()));
+    }
 
-            List<FlashcardResponse.WordItem> wordItems = session.getFlashcards().stream()
-                    .map(f -> new FlashcardResponse.WordItem(f.getWord(), f.getPartOfSpeech(), f.getPronunciation(), f.getMeaning()))
-                    .toList();
+    // 새 세션 생성 (LangChain 호출 + 저장)
+    private FlashcardResponse createFlashcardSession(String userId, Difficulty difficulty) {
+        log.info("[Flashcard] 단어 생성 요청 - userId: {}, difficulty: {}", userId, difficulty);
 
-            return new FlashcardResponse(session.getId(), wordItems);
-        }
-
-        // 미완료 세션 없으면 새 세션 생성
-        log.info("[Flashcard] 단어 생성 요청 - userId: {}, difficulty: {}", userId, user.getDifficulty());
-
-        LangChainFlashcardResponse langChainResponse = flashcardClient.generateWords(user.getDifficulty());
+        LangChainFlashcardResponse langChainResponse = flashcardClient.generateWords(difficulty);
 
         List<Flashcard> flashcards = langChainResponse.words().stream()
                 .map(w -> Flashcard.builder()
@@ -71,18 +69,21 @@ public class FlashcardService {
                 LearningSession.builder()
                         .userId(userId)
                         .date(LocalDate.now())
-                        .difficulty(user.getDifficulty())
+                        .difficulty(difficulty)
                         .flashcards(flashcards)
                         .build()
         );
 
         log.info("[Flashcard] 학습 세션 생성 완료 - userId: {}", userId);
 
-        List<FlashcardResponse.WordItem> wordItems = langChainResponse.words().stream()
-                .map(w -> new FlashcardResponse.WordItem(w.word(), w.partOfSpeech(), w.pronunciation(), w.meaning()))
-                .toList();
+        return new FlashcardResponse(saved.getId(), toWordItems(saved.getFlashcards()));
+    }
 
-        return new FlashcardResponse(saved.getId(), wordItems);
+    // Flashcard 리스트 → WordItem 리스트 변환
+    private List<FlashcardResponse.WordItem> toWordItems(List<Flashcard> flashcards) {
+        return flashcards.stream()
+                .map(f -> new FlashcardResponse.WordItem(f.getWord(), f.getPartOfSpeech(), f.getPronunciation(), f.getMeaning()))
+                .toList();
     }
 
     // 플래시카드 학습 완료 상태로 변경

--- a/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardService.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardService.java
@@ -19,6 +19,7 @@ import software_capstone.backend.global.exception.NotFoundException;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -37,6 +38,22 @@ public class FlashcardService {
             throw new BadRequestException(ErrorMessage.USER_NOT_ONBOARDED);
         }
 
+        // 오늘 미완료 세션이 있으면 기존 세션 반환
+        Optional<LearningSession> existingSession = learningSessionRepository
+                .findByUserIdAndDateAndFlashcardsCompletedFalse(userId, LocalDate.now());
+
+        if (existingSession.isPresent()) {
+            LearningSession session = existingSession.get();
+            log.info("[Flashcard] 기존 미완료 세션 반환 - userId: {}, sessionId: {}", userId, session.getId());
+
+            List<FlashcardResponse.WordItem> wordItems = session.getFlashcards().stream()
+                    .map(f -> new FlashcardResponse.WordItem(f.getWord(), f.getPartOfSpeech(), f.getPronunciation(), f.getMeaning()))
+                    .toList();
+
+            return new FlashcardResponse(session.getId(), wordItems);
+        }
+
+        // 미완료 세션 없으면 새 세션 생성
         log.info("[Flashcard] 단어 생성 요청 - userId: {}, difficulty: {}", userId, user.getDifficulty());
 
         LangChainFlashcardResponse langChainResponse = flashcardClient.generateWords(user.getDifficulty());

--- a/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardService.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardService.java
@@ -86,6 +86,17 @@ public class FlashcardService {
         log.info("[Flashcard] 학습 완료 처리 - userId: {}, sessionId: {}", userId, sessionId);
     }
 
+    // TTS 생성
+    public byte[] createTts(String text) {
+        if (text == null || text.isBlank()) {
+            throw new BadRequestException(ErrorMessage.EMPTY_TTS_TEXT);
+        }
+
+        log.info("[Flashcard] TTS 생성 요청 - text: {}", text);
+
+        return flashcardClient.createTts(text);
+    }
+
     // 발음 판정
     public PronunciationResponse getPronunciationFeedback(
             String userId, MultipartFile audioFile, String targetWord) {

--- a/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardService.java
+++ b/src/main/java/software_capstone/backend/app/flashcard/service/FlashcardService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import software_capstone.backend.app.flashcard.dto.FlashcardCompleteResponse;
 import software_capstone.backend.app.flashcard.dto.FlashcardResponse;
 import software_capstone.backend.app.flashcard.dto.LangChainFlashcardResponse;
 import software_capstone.backend.app.flashcard.dto.PronunciationResponse;
@@ -68,7 +69,7 @@ public class FlashcardService {
     }
 
     // 플래시카드 학습 완료 상태로 변경
-    public void completeFlashcard(String userId, String sessionId) {
+    public FlashcardCompleteResponse completeFlashcard(String userId, String sessionId) {
         LearningSession session = learningSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.LEARNING_SESSION_NOT_FOUND));
 
@@ -84,6 +85,14 @@ public class FlashcardService {
         learningSessionRepository.save(session);
 
         log.info("[Flashcard] 학습 완료 처리 - userId: {}, sessionId: {}", userId, sessionId);
+
+        int totalWordsToday = learningSessionRepository
+                .findAllByUserIdAndDate(userId, LocalDate.now())
+                .stream()
+                .mapToInt(s -> s.getFlashcards().size())
+                .sum();
+
+        return new FlashcardCompleteResponse(totalWordsToday);
     }
 
     // TTS 생성

--- a/src/main/java/software_capstone/backend/app/learning/document/Flashcard.java
+++ b/src/main/java/software_capstone/backend/app/learning/document/Flashcard.java
@@ -1,0 +1,26 @@
+package software_capstone.backend.app.learning.document;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Flashcard {
+
+    private String word;            // 단어
+
+    @Field("part_of_speech")
+    private String partOfSpeech;    // 품사
+
+    private String pronunciation;   // 발음 기호
+    private String meaning;         // 한국어 뜻
+
+    @Field("is_completed")
+    private boolean isCompleted;    // 해당 단어 학습 완료 여부
+}

--- a/src/main/java/software_capstone/backend/app/learning/document/LearningSession.java
+++ b/src/main/java/software_capstone/backend/app/learning/document/LearningSession.java
@@ -1,0 +1,54 @@
+package software_capstone.backend.app.learning.document;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import software_capstone.backend.app.abocado.document.Difficulty;
+import software_capstone.backend.global.document.BaseEntity;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Document(collection = "learning_sessions")
+public class LearningSession extends BaseEntity {
+
+    @Indexed
+    private String userId;
+
+    private LocalDate date;
+
+    private Difficulty difficulty;
+
+    @Builder.Default
+    private Status status = Status.IN_PROGRESS;
+
+    @Builder.Default
+    private List<Flashcard> flashcards = new ArrayList<>();
+
+    @Field("quiz_completed")
+    @Builder.Default
+    private boolean quizCompleted = false;
+
+    @Field("flashcards_completed")
+    @Builder.Default
+    private boolean flashcardsCompleted = false;
+
+    public void completeFlashcards() {
+        this.flashcardsCompleted = true;
+    }
+
+    public void complete() {
+        this.status = Status.COMPLETED;
+    }
+
+}

--- a/src/main/java/software_capstone/backend/app/learning/document/LearningSession.java
+++ b/src/main/java/software_capstone/backend/app/learning/document/LearningSession.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
-import software_capstone.backend.app.abocado.document.Difficulty;
+import software_capstone.backend.app.user.document.Difficulty;
 import software_capstone.backend.global.document.BaseEntity;
 
 import java.time.LocalDate;

--- a/src/main/java/software_capstone/backend/app/learning/document/Status.java
+++ b/src/main/java/software_capstone/backend/app/learning/document/Status.java
@@ -1,0 +1,5 @@
+package software_capstone.backend.app.learning.document;
+
+public enum Status {
+    IN_PROGRESS, COMPLETED
+}

--- a/src/main/java/software_capstone/backend/app/learning/repository/LearningSessionRepository.java
+++ b/src/main/java/software_capstone/backend/app/learning/repository/LearningSessionRepository.java
@@ -1,0 +1,14 @@
+package software_capstone.backend.app.learning.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import software_capstone.backend.app.learning.document.LearningSession;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface LearningSessionRepository extends MongoRepository<LearningSession, String> {
+
+    Optional<LearningSession> findByUserIdAndDate(String userId, LocalDate date);
+}

--- a/src/main/java/software_capstone/backend/app/learning/repository/LearningSessionRepository.java
+++ b/src/main/java/software_capstone/backend/app/learning/repository/LearningSessionRepository.java
@@ -13,5 +13,7 @@ public interface LearningSessionRepository extends MongoRepository<LearningSessi
 
     Optional<LearningSession> findByUserIdAndDate(String userId, LocalDate date);
 
+    Optional<LearningSession> findByUserIdAndDateAndFlashcardsCompletedFalse(String userId, LocalDate date);
+
     List<LearningSession> findAllByUserIdAndDate(String userId, LocalDate date);
 }

--- a/src/main/java/software_capstone/backend/app/learning/repository/LearningSessionRepository.java
+++ b/src/main/java/software_capstone/backend/app/learning/repository/LearningSessionRepository.java
@@ -5,10 +5,13 @@ import org.springframework.stereotype.Repository;
 import software_capstone.backend.app.learning.document.LearningSession;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface LearningSessionRepository extends MongoRepository<LearningSession, String> {
 
     Optional<LearningSession> findByUserIdAndDate(String userId, LocalDate date);
+
+    List<LearningSession> findAllByUserIdAndDate(String userId, LocalDate date);
 }

--- a/src/main/java/software_capstone/backend/global/config/SecurityConfig.java
+++ b/src/main/java/software_capstone/backend/global/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                                 "/auth/**",
                                 "/api/regions/**",
                                 "/swagger-ui/**",
-                                "/v3/api-docs/**"
+                                "/v3/api-docs/**",
+                                "/flashcard/tts"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
+++ b/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
@@ -7,6 +7,14 @@ public enum ErrorMessage {
     // User
     USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
     USER_ALREADY_ONBOARDED("이미 온보딩이 완료된 유저입니다."),
+    USER_NOT_ONBOARDED("온보딩이 완료되지 않은 유저입니다."),
+
+    // Learning
+    LEARNING_SESSION_NOT_FOUND("오늘의 학습 세션을 찾을 수 없습니다."),
+    SESSION_USER_MISMATCH("해당 학습 세션에 대한 권한이 없습니다."),
+    ALREADY_COMPLETED_SESSION("이미 완료된 학습 세션입니다."),
+    EMPTY_AUDIO_FILE("오디오 파일이 비어있습니다."),
+    LANGCHAIN_SERVER_ERROR("AI 서버와의 통신 중 오류가 발생했습니다."),
 
     // JWT
     INVALID_TOKEN("유효하지 않은 토큰입니다."),

--- a/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
+++ b/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
@@ -14,6 +14,7 @@ public enum ErrorMessage {
     SESSION_USER_MISMATCH("해당 학습 세션에 대한 권한이 없습니다."),
     ALREADY_COMPLETED_SESSION("이미 완료된 학습 세션입니다."),
     EMPTY_AUDIO_FILE("오디오 파일이 비어있습니다."),
+    EMPTY_TTS_TEXT("TTS 변환할 텍스트가 비어있습니다."),
     LANGCHAIN_SERVER_ERROR("AI 서버와의 통신 중 오류가 발생했습니다."),
 
     // JWT

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,9 @@ swagger:
     - ${APP_SERVER_URL}
     - ${STAGING_SERVER_URL}
 
+langchain:
+  base-url: ${LANGCHAIN_BASE_URL}
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 1800000       # 30분


### PR DESCRIPTION
## 📝 작업 내용
- 플래시카드 학습 세션 생성 기능 추가
- 플래시카드 학습 완료 처리 기능 추가
- 플래시카드 완료 시 오늘 누적 학습 단어 수 반환 기능 추가
- 단어 TTS 음성 변환 기능 추가
- 발음 판정 기능 추가

## 🔄 변경 사항
- GET /flashcard : 오늘의 플래시카드 단어 5개 조회 및 학습 세션 생성
- POST /flashcard/complete/{session-id} : 플래시카드 학습 완료 처리 및 오늘 누적 단어 수 반환
- POST /flashcard/tts : 단어 텍스트를 음성으로 변환
- POST /flashcard/pronunciation : 발음 판정

## 🔗 관련 이슈
Closes #30

## ✅ 체크리스트
- [x] 정상 동작 확인
- [ ] 불필요한 코드 없음
- [ ] 리뷰 반영 완료
