### PR TITLE
Feature#53: 소셜 로그인 콜백 딥링크 리다이렉트 처리

### DIFF
--- a/src/main/java/software_capstone/backend/app/auth/controller/AuthController.java
+++ b/src/main/java/software_capstone/backend/app/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package software_capstone.backend.app.auth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -12,11 +13,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 import software_capstone.backend.app.auth.dto.LoginRequest;
 import software_capstone.backend.app.auth.dto.RefreshRequest;
 import software_capstone.backend.app.auth.dto.TokenResponse;
 import software_capstone.backend.app.auth.jwt.TokenProvider;
 import software_capstone.backend.app.auth.service.AuthService;
+
+import java.net.URI;
 
 @Tag(name = "Auth", description = "소셜 로그인 및 토큰 관리 API")
 @RestController
@@ -58,7 +62,7 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "카카오 로그인 콜백", description = "카카오 OAuth 리다이렉트 콜백 엔드포인트입니다.")
+    /*@Operation(summary = "카카오 로그인 콜백", description = "카카오 OAuth 리다이렉트 콜백 엔드포인트입니다.")
     @GetMapping("/kakao/callback")
     public ResponseEntity<TokenResponse> kakaoCallback(
             @RequestParam String code,
@@ -72,5 +76,35 @@ public class AuthController {
             @RequestParam String code,
             @RequestParam(defaultValue = "web") String deviceInfo) {
         return ResponseEntity.ok(authService.naverLogin(new LoginRequest(code, deviceInfo)));
+    }*/
+
+    @Operation(summary = "카카오 로그인 콜백", description = "카카오 OAuth 리다이렉트 후 딥링크로 토큰을 전달합니다.")
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<Void> kakaoCallback(
+            @RequestParam String code,
+            @RequestParam(defaultValue = "web") String deviceInfo) {
+        TokenResponse token = authService.kakaoLogin(new LoginRequest(code, deviceInfo));
+        URI redirectUri = UriComponentsBuilder
+                .fromUriString("frontend://auth/kakao/callback")
+                .queryParam("accessToken", token.accessToken())
+                .queryParam("refreshToken", token.refreshToken())
+                .queryParam("isNewUser", token.isNewUser())
+                .build().toUri();
+        return ResponseEntity.status(HttpStatus.FOUND).location(redirectUri).build();
+    }
+
+    @Operation(summary = "네이버 로그인 콜백", description = "네이버 OAuth 리다이렉트 후 딥링크로 토큰을 전달합니다.")
+    @GetMapping("/naver/callback")
+    public ResponseEntity<Void> naverCallback(
+            @RequestParam String code,
+            @RequestParam(defaultValue = "web") String deviceInfo) {
+        TokenResponse token = authService.naverLogin(new LoginRequest(code, deviceInfo));
+        URI redirectUri = UriComponentsBuilder
+                .fromUriString("frontend://auth/naver/callback")
+                .queryParam("accessToken", token.accessToken())
+                .queryParam("refreshToken", token.refreshToken())
+                .queryParam("isNewUser", token.isNewUser())
+                .build().toUri();
+        return ResponseEntity.status(HttpStatus.FOUND).location(redirectUri).build();
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 소셜 로그인 콜백 엔드포인트에서 딥링크로 리다이렉트 처리

## 🔄 변경 사항
- `GET /auth/kakao/callback, GET /auth/naver/callback` 응답 방식 변경
기존: `ResponseEntity<TokenResponse>` 반환
변경: 로그인 처리 후 `frontend://auth/{provider}/callback?accessToken=...&refreshToken=...&isNewUser=...` 로 302 리다이렉트

## 🔗 관련 이슈
Closes #53

## ✅ 체크리스트
- [ ] 정상 동작 확인
- [x] 불필요한 코드 없음
- [ ] 리뷰 반영 완료
