### PR TITLE
Feature/#51: 예문 생성 기능 구현

### DIFF
--- a/src/main/java/software_capstone/backend/app/learning/document/LearningSession.java
+++ b/src/main/java/software_capstone/backend/app/learning/document/LearningSession.java
@@ -35,16 +35,24 @@ public class LearningSession extends BaseEntity {
     @Builder.Default
     private List<Flashcard> flashcards = new ArrayList<>();
 
-    @Field("quiz_completed")
     @Builder.Default
+    private List<Sentence> sentences = new ArrayList<>();
+
+    @Field("quiz_completed")
     private boolean quizCompleted = false;
 
     @Field("flashcards_completed")
-    @Builder.Default
     private boolean flashcardsCompleted = false;
+
+    @Field("sentences_completed")
+    private boolean sentencesCompleted = false;
 
     public void completeFlashcards() {
         this.flashcardsCompleted = true;
+    }
+
+    public void updateSentences(List<Sentence> sentences) {
+        this.sentences = new ArrayList<>(sentences);
     }
 
     public void complete() {

--- a/src/main/java/software_capstone/backend/app/learning/document/Sentence.java
+++ b/src/main/java/software_capstone/backend/app/learning/document/Sentence.java
@@ -1,0 +1,18 @@
+package software_capstone.backend.app.learning.document;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Sentence {
+
+    private String word;        // 해당 단어
+    private String sentence;    // 영어 예문
+    private String meaning;     // 한국어 해석
+}

--- a/src/main/java/software_capstone/backend/app/sentence/controller/SentenceController.java
+++ b/src/main/java/software_capstone/backend/app/sentence/controller/SentenceController.java
@@ -1,0 +1,49 @@
+package software_capstone.backend.app.sentence.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import software_capstone.backend.app.auth.jwt.TokenProvider;
+import software_capstone.backend.app.sentence.dto.SentenceResponse;
+import software_capstone.backend.app.sentence.service.SentenceService;
+
+@Tag(name = "Sentence", description = "예문 학습 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sentence")
+public class SentenceController {
+
+    private final SentenceService sentenceService;
+
+    @Operation(
+            summary = "예문 생성",
+            description = """
+                    플래시카드 학습이 완료된 세션의 단어를 기반으로 영어 예문을 생성합니다.
+
+                    플래시카드 학습 완료 후 반환된 sessionId를 요청 바디에 담아 요청해야 합니다.
+
+                    AI 서버에서 각 단어에 맞는 예문을 생성하여 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예문 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "플래시카드 학습 미완료이거나 세션 소유자가 아님"),
+            @ApiResponse(responseCode = "403", description = "토큰을 담아 요청하지 않음"),
+            @ApiResponse(responseCode = "404", description = "세션이 존재하지 않음")
+    })
+    @PostMapping
+    public ResponseEntity<SentenceResponse> createSentences(
+            @AuthenticationPrincipal TokenProvider.AuthUser authUser,
+            @RequestParam String sessionId
+    ) {
+        return ResponseEntity.ok(sentenceService.createSentences(authUser.userId(), sessionId));
+    }
+}

--- a/src/main/java/software_capstone/backend/app/sentence/dto/LangChainSentenceRequest.java
+++ b/src/main/java/software_capstone/backend/app/sentence/dto/LangChainSentenceRequest.java
@@ -1,0 +1,20 @@
+package software_capstone.backend.app.sentence.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import software_capstone.backend.app.user.document.Difficulty;
+
+import java.util.List;
+
+public record LangChainSentenceRequest(List<WordItem> words, String level) {
+
+    public LangChainSentenceRequest(List<WordItem> words, Difficulty difficulty) {
+        this(words, difficulty.name());
+    }
+
+    public record WordItem(
+            String word,
+            @JsonProperty("part_of_speech") String partOfSpeech,
+            String pronunciation,
+            String meaning
+    ) {}
+}

--- a/src/main/java/software_capstone/backend/app/sentence/dto/LangChainSentenceResponse.java
+++ b/src/main/java/software_capstone/backend/app/sentence/dto/LangChainSentenceResponse.java
@@ -1,0 +1,8 @@
+package software_capstone.backend.app.sentence.dto;
+
+import java.util.List;
+
+public record LangChainSentenceResponse(List<SentenceItem> sentences) {
+
+    public record SentenceItem(String word, String sentence, String meaning) {}
+}

--- a/src/main/java/software_capstone/backend/app/sentence/dto/SentenceResponse.java
+++ b/src/main/java/software_capstone/backend/app/sentence/dto/SentenceResponse.java
@@ -1,0 +1,8 @@
+package software_capstone.backend.app.sentence.dto;
+
+import java.util.List;
+
+public record SentenceResponse(String sessionId, List<SentenceItem> sentences) {
+
+    public record SentenceItem(String word, String sentence, String meaning) {}
+}

--- a/src/main/java/software_capstone/backend/app/sentence/service/SentenceClient.java
+++ b/src/main/java/software_capstone/backend/app/sentence/service/SentenceClient.java
@@ -1,0 +1,38 @@
+package software_capstone.backend.app.sentence.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import software_capstone.backend.app.sentence.dto.LangChainSentenceRequest;
+import software_capstone.backend.app.sentence.dto.LangChainSentenceResponse;
+import software_capstone.backend.global.exception.BadRequestException;
+import software_capstone.backend.global.exception.ErrorMessage;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SentenceClient {
+
+    private final WebClient webClient;
+
+    @Value("${langchain.base-url}")
+    private String langchainBaseUrl;
+
+    public LangChainSentenceResponse createSentences(LangChainSentenceRequest request) {
+        log.info("[SentenceClient] 예문 생성 요청 - level: {}, wordCount: {}", request.level(), request.words().size());
+
+        return webClient.post()
+                .uri(langchainBaseUrl + "/sentence")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .onStatus(status -> status.isError(), res ->
+                        res.bodyToMono(String.class)
+                                .map(body -> new BadRequestException(ErrorMessage.LANGCHAIN_SERVER_ERROR)))
+                .bodyToMono(LangChainSentenceResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/software_capstone/backend/app/sentence/service/SentenceService.java
+++ b/src/main/java/software_capstone/backend/app/sentence/service/SentenceService.java
@@ -1,0 +1,72 @@
+package software_capstone.backend.app.sentence.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import software_capstone.backend.app.learning.document.LearningSession;
+import software_capstone.backend.app.learning.document.Sentence;
+import software_capstone.backend.app.learning.repository.LearningSessionRepository;
+import software_capstone.backend.app.sentence.dto.LangChainSentenceRequest;
+import software_capstone.backend.app.sentence.dto.LangChainSentenceResponse;
+import software_capstone.backend.app.sentence.dto.SentenceResponse;
+import software_capstone.backend.global.exception.BadRequestException;
+import software_capstone.backend.global.exception.ErrorMessage;
+import software_capstone.backend.global.exception.NotFoundException;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SentenceService {
+
+    private final SentenceClient sentenceClient;
+    private final LearningSessionRepository learningSessionRepository;
+
+    // 예문 생성
+    public SentenceResponse createSentences(String userId, String sessionId) {
+        LearningSession session = learningSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.LEARNING_SESSION_NOT_FOUND));
+
+        if (!session.getUserId().equals(userId)) {
+            throw new BadRequestException(ErrorMessage.SESSION_USER_MISMATCH);
+        }
+
+        if (!session.isFlashcardsCompleted()) {
+            throw new BadRequestException(ErrorMessage.FLASHCARDS_NOT_COMPLETED);
+        }
+
+        log.info("[Sentence] 예문 생성 요청 - userId: {}, sessionId: {}", userId, sessionId);
+
+        List<LangChainSentenceRequest.WordItem> wordItems = session.getFlashcards().stream()
+                .map(f -> new LangChainSentenceRequest.WordItem(
+                        f.getWord(),
+                        f.getPartOfSpeech(),
+                        f.getPronunciation(),
+                        f.getMeaning()
+                ))
+                .toList();
+
+        LangChainSentenceRequest request = new LangChainSentenceRequest(wordItems, session.getDifficulty());
+        LangChainSentenceResponse langChainResponse = sentenceClient.createSentences(request);
+
+        List<Sentence> sentences = langChainResponse.sentences().stream()
+                .map(s -> Sentence.builder()
+                        .word(s.word())
+                        .sentence(s.sentence())
+                        .meaning(s.meaning())
+                        .build())
+                .toList();
+
+        session.updateSentences(sentences);
+        learningSessionRepository.save(session);
+
+        log.info("[Sentence] 예문 생성 완료 - userId: {}, sessionId: {}", userId, sessionId);
+
+        List<SentenceResponse.SentenceItem> responseItems = langChainResponse.sentences().stream()
+                .map(s -> new SentenceResponse.SentenceItem(s.word(), s.sentence(), s.meaning()))
+                .toList();
+
+        return new SentenceResponse(sessionId, responseItems);
+    }
+}

--- a/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
+++ b/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
@@ -13,6 +13,7 @@ public enum ErrorMessage {
     LEARNING_SESSION_NOT_FOUND("오늘의 학습 세션을 찾을 수 없습니다."),
     SESSION_USER_MISMATCH("해당 학습 세션에 대한 권한이 없습니다."),
     ALREADY_COMPLETED_SESSION("이미 완료된 학습 세션입니다."),
+    FLASHCARDS_NOT_COMPLETED("플래시카드 학습이 완료되지 않은 세션입니다."),
     EMPTY_AUDIO_FILE("오디오 파일이 비어있습니다."),
     EMPTY_TTS_TEXT("TTS 변환할 텍스트가 비어있습니다."),
     LANGCHAIN_SERVER_ERROR("AI 서버와의 통신 중 오류가 발생했습니다."),


### PR DESCRIPTION
## 📝 작업 내용
- 플래시카드 학습 완료 후 해당 단어들을 기반으로 영어 예문을 생성하는 기능을 구현했습니다.

## 🔄 변경 사항
- `Sentence` 도큐먼트 추가 (word, sentence, meaning 필드)
- `LearningSession`에 `sentences`, `sentencesCompleted` 필드 및 `updateSentences()`, `completeSentences()` 메서드 추가
- `POST /sentence` 엔드포인트 추가
- 예문 생성 관련 에러 메시지 추가 (`FLASHCARDS_NOT_COMPLETED`)

## 🔗 관련 이슈
Closes #51

## ✅ 체크리스트
- [x] 정상 동작 확인
- [x] 불필요한 코드 없음
- [ ] 리뷰 반영 완료
