### PR TITLE
Refactor/#59: 소셜 로그인 콜백을 인가코드 전달 방식으로 변경

### DIFF
--- a/src/main/java/software_capstone/backend/app/auth/controller/AuthController.java
+++ b/src/main/java/software_capstone/backend/app/auth/controller/AuthController.java
@@ -62,48 +62,22 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    /*@Operation(summary = "카카오 로그인 콜백", description = "카카오 OAuth 리다이렉트 콜백 엔드포인트입니다.")
+    @Operation(summary = "카카오 로그인 콜백", description = "카카오 OAuth 인가코드를 프론트 딥링크로 전달합니다.")
     @GetMapping("/kakao/callback")
-    public ResponseEntity<TokenResponse> kakaoCallback(
-            @RequestParam String code,
-            @RequestParam(defaultValue = "web") String deviceInfo) {
-        return ResponseEntity.ok(authService.kakaoLogin(new LoginRequest(code, deviceInfo)));
-    }
-
-    @Operation(summary = "네이버 로그인 콜백", description = "네이버 OAuth 리다이렉트 콜백 엔드포인트입니다.")
-    @GetMapping("/naver/callback")
-    public ResponseEntity<TokenResponse> naverCallback(
-            @RequestParam String code,
-            @RequestParam(defaultValue = "web") String deviceInfo) {
-        return ResponseEntity.ok(authService.naverLogin(new LoginRequest(code, deviceInfo)));
-    }*/
-
-    @Operation(summary = "카카오 로그인 콜백", description = "카카오 OAuth 리다이렉트 후 딥링크로 토큰을 전달합니다.")
-    @GetMapping("/kakao/callback")
-    public ResponseEntity<Void> kakaoCallback(
-            @RequestParam String code,
-            @RequestParam(defaultValue = "web") String deviceInfo) {
-        TokenResponse token = authService.kakaoLogin(new LoginRequest(code, deviceInfo));
+    public ResponseEntity<Void> kakaoCallback(@RequestParam String code) {
         URI redirectUri = UriComponentsBuilder
                 .fromUriString("frontend://auth/kakao/callback")
-                .queryParam("accessToken", token.accessToken())
-                .queryParam("refreshToken", token.refreshToken())
-                .queryParam("isNewUser", token.isNewUser())
+                .queryParam("code", code)
                 .build().toUri();
         return ResponseEntity.status(HttpStatus.FOUND).location(redirectUri).build();
     }
 
-    @Operation(summary = "네이버 로그인 콜백", description = "네이버 OAuth 리다이렉트 후 딥링크로 토큰을 전달합니다.")
+    @Operation(summary = "네이버 로그인 콜백", description = "네이버 OAuth 인가코드를 프론트 딥링크로 전달합니다.")
     @GetMapping("/naver/callback")
-    public ResponseEntity<Void> naverCallback(
-            @RequestParam String code,
-            @RequestParam(defaultValue = "web") String deviceInfo) {
-        TokenResponse token = authService.naverLogin(new LoginRequest(code, deviceInfo));
+    public ResponseEntity<Void> naverCallback(@RequestParam String code) {
         URI redirectUri = UriComponentsBuilder
                 .fromUriString("frontend://auth/naver/callback")
-                .queryParam("accessToken", token.accessToken())
-                .queryParam("refreshToken", token.refreshToken())
-                .queryParam("isNewUser", token.isNewUser())
+                .queryParam("code", code)
                 .build().toUri();
         return ResponseEntity.status(HttpStatus.FOUND).location(redirectUri).build();
     }


### PR DESCRIPTION
## 📝 작업 내용
- 소셜 로그인 콜백 엔드포인트 역할 변경 (토큰 발급 → 인가코드 전달)

## 🔄 변경 사항
- `GET /auth/{provider}/callback`에서 인가코드만 프론트 딥링크로 전달하도록 변경
- 프론트에서 딥링크로 인가코드 수신 후, deviceInfo와 함께 POST /auth/kakao(naver)로 요청하는 구조로 변경

## 🔗 관련 이슈
Closes #59

## ✅ 체크리스트
- [x] 정상 동작 확인
- [x] 불필요한 코드 없음
- [x] 리뷰 반영 완료
