### PR TITLE
Feature/#28: 지갑 도메인 구현 및 보유 캐시/골드 조회 API

### DIFF
--- a/src/main/java/software_capstone/backend/app/store/service/ShopService.java
+++ b/src/main/java/software_capstone/backend/app/store/service/ShopService.java
@@ -10,8 +10,9 @@ import software_capstone.backend.app.store.dto.request.PurchaseRequest;
 import software_capstone.backend.app.store.dto.response.PurchaseResponse;
 import software_capstone.backend.app.store.dto.response.ShopItemResponse;
 import software_capstone.backend.app.store.repository.ShopItemRepository;
-import software_capstone.backend.app.user.document.User;
 import software_capstone.backend.app.user.service.UserService;
+import software_capstone.backend.app.wallet.document.Wallet;
+import software_capstone.backend.app.wallet.service.WalletService;
 import software_capstone.backend.global.exception.ErrorMessage;
 import software_capstone.backend.global.exception.NotFoundException;
 
@@ -21,8 +22,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ShopService {
     private final ShopItemRepository shopItemRepository;
+    private final WalletService walletService;
     private final InventoryService inventoryService;
-    private final PurchaseHistoryService purchaseHistoryService;
     private final UserService userService;
 
     @Transactional(readOnly = true)
@@ -40,17 +41,16 @@ public class ShopService {
 
     @Transactional
     public PurchaseResponse purchaseItem(String userId, PurchaseRequest request) {
-        User user = userService.findUserById(userId);
+        userService.findUserById(userId);
 
         ShopItem item = shopItemRepository.findByIdAndIsReleasedTrue(request.getItemId())
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.ITEM_NOT_FOUND));
 
-        user.deductCash(item.getPrice());
-        userService.save(user);
+        walletService.deductCash(userId, item.getPrice());
 
         inventoryService.addItem(userId, item);
-        purchaseHistoryService.save(userId, item);
 
-        return PurchaseResponse.of(item, user.getCash());
+        Wallet wallet = walletService.findWalletByUserId(userId);
+        return PurchaseResponse.of(item, wallet.getCash());
     }
 }

--- a/src/main/java/software_capstone/backend/app/user/document/User.java
+++ b/src/main/java/software_capstone/backend/app/user/document/User.java
@@ -25,7 +25,6 @@ public class User extends BaseEntity {
     private Role role;
     private Difficulty difficulty;
     private LocalDateTime onBoardedAt;
-    private int cash;
 
     public boolean isOnboarded() {
         return onBoardedAt != null;
@@ -37,12 +36,5 @@ public class User extends BaseEntity {
         }
         this.difficulty = difficulty;
         this.onBoardedAt = LocalDateTime.now();
-    }
-
-    public void deductCash(int amount) {
-        if (this.cash < amount) {
-            throw new BadRequestException(ErrorMessage.INSUFFICIENT_CASH);
-        }
-        this.cash -= amount;
     }
 }

--- a/src/main/java/software_capstone/backend/app/wallet/controller/WalletController.java
+++ b/src/main/java/software_capstone/backend/app/wallet/controller/WalletController.java
@@ -1,0 +1,26 @@
+package software_capstone.backend.app.wallet.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import software_capstone.backend.app.auth.jwt.TokenProvider;
+import software_capstone.backend.app.wallet.dto.WalletResponse;
+import software_capstone.backend.app.wallet.service.WalletService;
+
+@RestController
+@RequestMapping("/wallet")
+@RequiredArgsConstructor
+public class WalletController implements WalletControllerDocs {
+    private final WalletService walletService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<WalletResponse> getWallet(
+            @AuthenticationPrincipal TokenProvider.AuthUser authUser
+    ) {
+        return ResponseEntity.ok(walletService.getWallet(authUser.userId()));
+    }
+}

--- a/src/main/java/software_capstone/backend/app/wallet/controller/WalletControllerDocs.java
+++ b/src/main/java/software_capstone/backend/app/wallet/controller/WalletControllerDocs.java
@@ -1,0 +1,26 @@
+package software_capstone.backend.app.wallet.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import software_capstone.backend.app.auth.jwt.TokenProvider;
+import software_capstone.backend.app.wallet.dto.WalletResponse;
+
+public interface WalletControllerDocs {
+    @Operation(
+            summary = "보유 캐시 / 골드 조회",
+            description =
+                    """
+                    유저의 보유 캐시와 골드를 조회합니다.
+                    
+                    토큰으로 받아온 유저가 존재하지 않다면 에러가 발생합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "캐시 / 골드 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "토큰을 담아 요청하지 않음"),
+            @ApiResponse(responseCode = "404", description = "유저 또는 지갑을 찾을 수 없음")
+    })
+    ResponseEntity<WalletResponse> getWallet(TokenProvider.AuthUser authUser);
+}

--- a/src/main/java/software_capstone/backend/app/wallet/document/Wallet.java
+++ b/src/main/java/software_capstone/backend/app/wallet/document/Wallet.java
@@ -1,0 +1,49 @@
+package software_capstone.backend.app.wallet.document;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import software_capstone.backend.global.document.BaseEntity;
+import software_capstone.backend.global.exception.BadRequestException;
+import software_capstone.backend.global.exception.ErrorMessage;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Document(collection = "wallets")
+public class Wallet extends BaseEntity {
+
+    @Indexed
+    private String userId;
+    @Builder.Default
+    private int cash = 0;
+    @Builder.Default
+    private int gold = 0;
+
+    public void chargeCash(int amount) {
+        this.cash += amount;
+    }
+
+    public void deductCash(int amount) {
+        if (this.cash < amount) {
+            throw new BadRequestException(ErrorMessage.INSUFFICIENT_CASH);
+        }
+        this.cash -= amount;
+    }
+
+    public void chargeGold(int amount) {
+        this.gold += amount;
+    }
+
+    public void deductGold(int amount) {
+        if (this.gold < amount) {
+            throw new BadRequestException(ErrorMessage.INSUFFICIENT_GOLD);
+        }
+        this.gold -= amount;
+    }
+}

--- a/src/main/java/software_capstone/backend/app/wallet/dto/WalletResponse.java
+++ b/src/main/java/software_capstone/backend/app/wallet/dto/WalletResponse.java
@@ -1,0 +1,19 @@
+package software_capstone.backend.app.wallet.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import software_capstone.backend.app.wallet.document.Wallet;
+
+@Getter
+@Builder
+public class WalletResponse {
+    private int cash;
+    private int gold;
+
+    public static WalletResponse from(Wallet wallet) {
+        return WalletResponse.builder()
+                .cash(wallet.getCash())
+                .gold(wallet.getGold())
+                .build();
+    }
+}

--- a/src/main/java/software_capstone/backend/app/wallet/repository/WalletRepository.java
+++ b/src/main/java/software_capstone/backend/app/wallet/repository/WalletRepository.java
@@ -1,0 +1,12 @@
+package software_capstone.backend.app.wallet.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import software_capstone.backend.app.wallet.document.Wallet;
+
+import java.util.Optional;
+
+@Repository
+public interface WalletRepository extends MongoRepository<Wallet, String> {
+    Optional<Wallet> findByUserId(String userId);
+}

--- a/src/main/java/software_capstone/backend/app/wallet/service/WalletService.java
+++ b/src/main/java/software_capstone/backend/app/wallet/service/WalletService.java
@@ -1,0 +1,46 @@
+package software_capstone.backend.app.wallet.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import software_capstone.backend.app.user.service.UserService;
+import software_capstone.backend.app.wallet.document.Wallet;
+import software_capstone.backend.app.wallet.dto.WalletResponse;
+import software_capstone.backend.app.wallet.repository.WalletRepository;
+import software_capstone.backend.global.exception.ErrorMessage;
+import software_capstone.backend.global.exception.NotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class WalletService {
+    private final WalletRepository walletRepository;
+    private final UserService userService;
+
+    public Wallet findWalletByUserId(String userId) {
+        return walletRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.WALLET_NOT_FOUND));
+    }
+
+    public void deductCash(String userId, int amount) {
+        Wallet wallet = findWalletByUserId(userId);
+        wallet.deductCash(amount);
+        walletRepository.save(wallet);
+    }
+
+    public void chargeCash(String userId, int amount) {
+        Wallet wallet = findWalletByUserId(userId);
+        wallet.chargeCash(amount);
+        walletRepository.save(wallet);
+    }
+
+    public void chargeGold(String userId, int amount) {
+        Wallet wallet = findWalletByUserId(userId);
+        wallet.chargeGold(amount);
+        walletRepository.save(wallet);
+    }
+
+    public WalletResponse getWallet(String userId) {
+        userService.validateUserExists(userId);
+        Wallet wallet = findWalletByUserId(userId);
+        return WalletResponse.from(wallet);
+    }
+}

--- a/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
+++ b/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
@@ -29,7 +29,11 @@ public enum ErrorMessage {
     // store
     INSUFFICIENT_ITEM("아이템이 부족합니다."),
     ITEM_NOT_FOUND("아이템을 찾을 수 없습니다."),
-    INSUFFICIENT_CASH("캐시가 부족합니다.");
+    INSUFFICIENT_CASH("캐시가 부족합니다."),
+
+    // wallet
+    INSUFFICIENT_GOLD("골드가 부족합니다."),
+    WALLET_NOT_FOUND("지갑을 찾을 수 없습니다.");
     private final String message;
 
     ErrorMessage(String message) {


### PR DESCRIPTION
## 📝 작업 내용
- 지갑 도메인 구현 및 보유 캐시/골드 조회 API 구현
- 기존 User의 cash 필드를 Wallet으로 분리

## 🔄 변경 사항
- Wallet 도메인 및 WalletRepository 추가
- WalletService 캐시/골드 충전, 차감, 조회 로직 추가
- WalletController GET /wallet API 추가
- WalletControllerDocs 보유 캐시/골드 조회 Swagger 명세 추가
- WalletResponse 추가
- ShopService deductCash WalletService로 교체
- User cash 필드 및 deductCash 메서드 제거
- ErrorMessage WALLET_NOT_FOUND, INSUFFICIENT_GOLD 추가

## 🔗 관련 이슈
Closes #28

## ✅ 체크리스트
- [ ] 정상 동작 확인
- [ ] 불필요한 코드 없음
- [ ] 리뷰 반영 완료