### PR TITLE
Feature/#52: 예문 학습 완료 기능 구현

### DIFF
--- a/src/main/java/software_capstone/backend/app/learning/document/LearningSession.java
+++ b/src/main/java/software_capstone/backend/app/learning/document/LearningSession.java
@@ -55,6 +55,10 @@ public class LearningSession extends BaseEntity {
         this.sentences = new ArrayList<>(sentences);
     }
 
+    public void completeSentences() {
+        this.sentencesCompleted = true;
+    }
+
     public void complete() {
         this.status = Status.COMPLETED;
     }

--- a/src/main/java/software_capstone/backend/app/sentence/controller/SentenceController.java
+++ b/src/main/java/software_capstone/backend/app/sentence/controller/SentenceController.java
@@ -7,11 +7,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import software_capstone.backend.app.auth.jwt.TokenProvider;
+import software_capstone.backend.app.sentence.dto.SentenceCompleteResponse;
 import software_capstone.backend.app.sentence.dto.SentenceResponse;
 import software_capstone.backend.app.sentence.service.SentenceService;
 
@@ -39,11 +40,33 @@ public class SentenceController {
             @ApiResponse(responseCode = "403", description = "토큰을 담아 요청하지 않음"),
             @ApiResponse(responseCode = "404", description = "세션이 존재하지 않음")
     })
-    @PostMapping
+    @PostMapping("/{session-id}")
     public ResponseEntity<SentenceResponse> createSentences(
             @AuthenticationPrincipal TokenProvider.AuthUser authUser,
-            @RequestParam String sessionId
+            @PathVariable("session-id") String sessionId
     ) {
         return ResponseEntity.ok(sentenceService.createSentences(authUser.userId(), sessionId));
+    }
+
+    @Operation(
+            summary = "예문 학습 완료",
+            description = """
+                    예문 학습을 완료 처리합니다.
+
+                    예문 생성 시 반환된 sessionId를 경로에 담아 요청해야 합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예문 학습 완료 처리 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 완료된 세션이거나 세션 소유자가 아님"),
+            @ApiResponse(responseCode = "403", description = "토큰을 담아 요청하지 않음"),
+            @ApiResponse(responseCode = "404", description = "세션이 존재하지 않음")
+    })
+    @PostMapping("/complete/{session-id}")
+    public ResponseEntity<SentenceCompleteResponse> completeSentences(
+            @AuthenticationPrincipal TokenProvider.AuthUser authUser,
+            @PathVariable("session-id") String sessionId
+    ) {
+        return ResponseEntity.ok(sentenceService.completeSentences(authUser.userId(), sessionId));
     }
 }

--- a/src/main/java/software_capstone/backend/app/sentence/dto/SentenceCompleteResponse.java
+++ b/src/main/java/software_capstone/backend/app/sentence/dto/SentenceCompleteResponse.java
@@ -1,0 +1,3 @@
+package software_capstone.backend.app.sentence.dto;
+
+public record SentenceCompleteResponse(int totalSentencesToday) {}

--- a/src/main/java/software_capstone/backend/app/sentence/service/SentenceService.java
+++ b/src/main/java/software_capstone/backend/app/sentence/service/SentenceService.java
@@ -8,11 +8,13 @@ import software_capstone.backend.app.learning.document.Sentence;
 import software_capstone.backend.app.learning.repository.LearningSessionRepository;
 import software_capstone.backend.app.sentence.dto.LangChainSentenceRequest;
 import software_capstone.backend.app.sentence.dto.LangChainSentenceResponse;
+import software_capstone.backend.app.sentence.dto.SentenceCompleteResponse;
 import software_capstone.backend.app.sentence.dto.SentenceResponse;
 import software_capstone.backend.global.exception.BadRequestException;
 import software_capstone.backend.global.exception.ErrorMessage;
 import software_capstone.backend.global.exception.NotFoundException;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Slf4j
@@ -68,5 +70,32 @@ public class SentenceService {
                 .toList();
 
         return new SentenceResponse(sessionId, responseItems);
+    }
+
+    // 예문 학습 완료 상태로 변경
+    public SentenceCompleteResponse completeSentences(String userId, String sessionId) {
+        LearningSession session = learningSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.LEARNING_SESSION_NOT_FOUND));
+
+        if (!session.getUserId().equals(userId)) {
+            throw new BadRequestException(ErrorMessage.SESSION_USER_MISMATCH);
+        }
+
+        if (session.isSentencesCompleted()) {
+            throw new BadRequestException(ErrorMessage.ALREADY_COMPLETED_SENTENCES);
+        }
+
+        session.completeSentences();
+        learningSessionRepository.save(session);
+
+        log.info("[Sentence] 예문 학습 완료 처리 - userId: {}, sessionId: {}", userId, sessionId);
+
+        int totalSentencesToday = learningSessionRepository
+                .findAllByUserIdAndDate(userId, LocalDate.now())
+                .stream()
+                .mapToInt(s -> s.getSentences().size())
+                .sum();
+
+        return new SentenceCompleteResponse(totalSentencesToday);
     }
 }

--- a/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
+++ b/src/main/java/software_capstone/backend/global/exception/ErrorMessage.java
@@ -14,6 +14,7 @@ public enum ErrorMessage {
     SESSION_USER_MISMATCH("해당 학습 세션에 대한 권한이 없습니다."),
     ALREADY_COMPLETED_SESSION("이미 완료된 학습 세션입니다."),
     FLASHCARDS_NOT_COMPLETED("플래시카드 학습이 완료되지 않은 세션입니다."),
+    ALREADY_COMPLETED_SENTENCES("이미 예문 학습이 완료된 세션입니다."),
     EMPTY_AUDIO_FILE("오디오 파일이 비어있습니다."),
     EMPTY_TTS_TEXT("TTS 변환할 텍스트가 비어있습니다."),
     LANGCHAIN_SERVER_ERROR("AI 서버와의 통신 중 오류가 발생했습니다."),


### PR DESCRIPTION
## 📝 작업 내용
- 예문 학습 완료 처리 및 오늘 학습한 예문 수를 반환하는 기능을 구현했습니다.

## 🔄 변경 사항
- `SentenceCompleteResponse` DTO 추가 (totalSentencesToday 필드)
- `LearningSession`에 `completeSentences()` 메서드 추가
- `POST /sentence/complete/{session-id}` 엔드포인트 추가
- 예문 학습 완료 관련 에러 메시지 추가 (`ALREADY_COMPLETED_SENTENCES`)

## 🔗 관련 이슈
Closes #52 

## ✅ 체크리스트
- [ ] 정상 동작 확인
- [ ] 불필요한 코드 없음
- [ ] 리뷰 반영 완료
